### PR TITLE
convert to data frame in toolAggregate()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 1.53.0
-Date: 2018-10-18
+Version: 1.53.1
+Date: 2018-10-26
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
              person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = "aut"),
@@ -37,4 +37,4 @@ LazyData: no
 Encoding: UTF-8
 RoxygenNote: 6.1.0
 VignetteBuilder: knitr
-ValidationKey: 27267660
+ValidationKey: 27297730

--- a/R/toolAggregate.R
+++ b/R/toolAggregate.R
@@ -74,6 +74,9 @@ toolAggregate <- function(x, rel, weight=NULL, from=NULL, to=NULL, dim=1, partre
   if(!is.numeric(rel) & !("spam" %in% class(rel))) {
     .getAggregationMatrix <- function(rel,from=NULL,to=NULL) {
       
+      if("tbl" %in% class(rel)){
+        rel <- data.frame(rel)
+      }
       if(!(is.matrix(rel) | is.data.frame(rel))) {
         if(!file.exists(rel)) stop("Cannot find given region mapping file!")
         rel <- read.csv(rel, as.is = TRUE, sep = ";")     


### PR DESCRIPTION
toolAggregate() fails with a somewhat unhelpful message when called with a tibble (instead of a data frame) as a relation matrix. tibbles are the default return for some newer read-in function (such as readxl:read_excel ), so I thought it was worth adding the option to use them by adding a conversion to data frame at the beginning of toolAggregate().

Minimal (non-)working example:

```
library(madrat)
library(magclass)
library(tibble)
x <- new.magpie(cells_and_regions = c('A', 'B', 'C', 'D'),
                years = 2000,
                names = 'dummy',
                fill = 1:4)
relmatrix <- tibble(CountryCode = c('A', 'B', 'C', 'D'),
                    RegionCode = c('XX', 'XX', 'YY', 'YY'))
# this works
toolAggregate(x, rel = data.frame(relmatrix))
# this fails (prior to fix)
toolAggregate(x, rel = relmatrix)
```
Edit: formatting of example