### PR TITLE
Updated cache format in readSource

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 1.70.0
-Date: 2020-03-16
+Version: 1.71.0
+Date: 2020-03-17
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
              person("Stephen", "Wirth", email = "wirth@pik-potsdam.de", role = "aut"),
@@ -36,6 +36,6 @@ BugReports: https://github.com/pik-piam/madrat/issues
 License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 VignetteBuilder: knitr
-ValidationKey: 31172900
+ValidationKey: 31357980

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -155,7 +155,7 @@ calcOutput <- function(type,aggregate=TRUE,file=NULL,years=NULL,round=NULL,suppl
       }
       x$package <- attr(functionname,"pkgcomment")
       saveRDS(x, file=tmppath, compress = getConfig("cachecompression"))
-      Sys.chmod(tmppath, mode = "0777", use_umask = TRUE)
+      Sys.chmod(tmppath, mode = "0666", use_umask = FALSE)
       break
     }  
   }


### PR DESCRIPTION
- updated cache format from mz to rds in readSource to be consistent with calcOutput
- updated file permission settings for cache files