### PR TITLE
No need for convertSource functions for non-ISO sources

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 1.74.1
+Version: 1.75.0
 Date: 2020-03-20
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
@@ -38,4 +38,4 @@ LazyData: no
 Encoding: UTF-8
 RoxygenNote: 7.1.0
 VignetteBuilder: knitr
-ValidationKey: 31931681
+ValidationKey: 32096750

--- a/R/getSources.R
+++ b/R/getSources.R
@@ -6,9 +6,8 @@
 #' 
 #' 
 #' @aliases getSources
-#' @param type Type of source, either set to "global" "regional", "download", "correct" or
-#' NULL. Global returns all global sources (non-regional), regional returns
-#' sources with regional data, "download" returns source for which a download
+#' @param type Type of source, either set to "regional", "download", "correct" or
+#' NULL. Regional returns sources with regional data, "download" returns source for which a download
 #' function is available, "correct" returns sources for which a correct function
 #' is available and NULL returns all available sources
 #' @param packages A character vector with packages for which the available Sources/Calculations should be returned
@@ -43,8 +42,6 @@ getSources <- function(type=NULL, packages=getConfig("packages"), globalenv=getC
   
   if(is.null(type)) {
     out <- read    
-  } else if(type=="global") {
-    out <- setdiff(read,convert)
   } else if(type=="regional") {
     out <- intersect(read,convert)
   } else if(type=="correct") {


### PR DESCRIPTION
nonISO sources do not require anymore to write a convert function. Convert functions for these sources can now be deleted.