### PR TITLE
Hashing based on sample content and file size

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '206304201'
+ValidationKey: '206382450'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "1.100.7",
+  "version": "1.101.0",
   "description": "<p>Provides a framework which should improve reproducibility and transparency in data processing. It provides functionality such as automatic meta data creation and management, rudimentary quality management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this package to deliver everything what is needed to achieve full reproducibility and transparency, but we believe that it supports efforts in this direction.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 1.100.7
-Date: 2021-04-26
+Version: 1.101.0
+Date: 2021-04-28
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
              person("Stephen", "Wirth", email = "wirth@pik-potsdam.de", role = "aut"),

--- a/R/downloadTau.R
+++ b/R/downloadTau.R
@@ -12,7 +12,7 @@ downloadTau <- function(subtype="paper") {
                                              doi = "10.5281/zenodo.4282548"))
   meta <- toolSubtypeSelect(subtype,settings)
   
-  download.file(meta$url, destfile = "tau.zip")
+  download.file(meta$url, destfile = "tau.zip", quiet = testthat::is_testing())
   unzip("tau.zip")
   unlink("tau.zip")
   

--- a/R/setConfig.R
+++ b/R/setConfig.R
@@ -3,8 +3,8 @@
 #' This function manipulates the current madrat configuration. 
 #' In general, NULL means that the argument remains as it is whereas
 #' all other inputs will overwrite the current setting.
-#' For values which can be reset to NULL (currenly only "extramappings") 
-#' you can achieve an reset by setting the value to "".
+#' For values which can be reset to NULL (currently only "extramappings")
+#' you can achieve a reset by setting the value to "".
 #' 
 #' 
 #' @param regionmapping The name of the csv file containing the region mapping
@@ -63,13 +63,14 @@
 #' @param diagnostics file name for additional diagnostics information (without file ending).
 #' 2 log files be written if a file name is provided (a compact version with the most
 #' relevant information and a full version with all available details).
-#' @param nocores  integer number of cores to use
+#' @param nocores integer number of cores to use
 #' @param debug Boolean which activates a debug mode. In debug mode all calculations will
 #' be executed with try=TRUE so that calculations do not stop even if the previous calculation failed.
 #' This can be helpful to get a full picture of errors rather than only seeing the first one. In addition
 #' debug=TRUE will add the suffix "debug" to the files created to avoid there use in productive runs.
 #' Furthermore, with debug=TRUE calculations will be rerun even if a corresponding tgz file 
 #' already exists.
+#' @param indentationCharacter character used for indenting the output of nested function calls
 #' @param .cfgchecks boolean deciding whether the given inputs to setConfig should be checked for
 #' consistency or just be accepted (latter is only necessary in very rare cases and should not be used
 #' in regular cases)
@@ -104,6 +105,7 @@ setConfig <- function(regionmapping=NULL,
                       diagnostics=NULL,
                       nocores=NULL,
                       debug=NULL,
+                      indentationCharacter=NULL,
                       .cfgchecks=TRUE,
                       .verbose=TRUE){
   cfg <- getConfig(raw=TRUE, verbose=.verbose)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **1.100.7**
+R package **madrat**, version **1.101.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490)  [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/madrat)
 
@@ -48,10 +48,9 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U,
-Klein D, Führlich P (2021). _madrat: May All Data be Reproducible and Transparent (MADRaT)_.
-doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version
-1.100.7, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P
+(2021). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL:
+https://doi.org/10.5281/zenodo.1115490), R package version 1.101.0, <URL: https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -60,7 +59,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2021},
-  note = {R package version 1.100.7},
+  note = {R package version 1.101.0},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/tests/testthat/test-fingerprint.R
+++ b/tests/testthat/test-fingerprint.R
@@ -17,7 +17,7 @@ test_that("fingerprinting works as expected", {
   expect_equivalent(madrat:::fingerprint("toolTest", packages = "madrat", globalenv = TRUE), "8b3413cc")
   emptyfolder <- paste0(tempdir(),"/empty")
   dir.create(emptyfolder, recursive = TRUE, showWarnings = FALSE)
-  expect_equal(unname(madrat:::fingerprintFiles(emptyfolder, use.mtime = TRUE)), "ca265a9c")
+  expect_equal(unname(madrat:::fingerprintFiles(emptyfolder)), "9ffb1463")
   unlink(emptyfolder)
 })
 
@@ -27,8 +27,8 @@ test_that("fingerprintFiles works as expected", {
   setwd(tempdir())
   on.exit(setwd(cwd))
   writeLines("this is a test","test.txt")
-  fp <- madrat:::fingerprintFiles("test.txt", use.mtime = FALSE)
-  expect_identical(fp, c(test.txt="7e76cec7"))
+  fp <- madrat:::fingerprintFiles("test.txt")
+  expect_identical(fp, c(test.txt="515abfd5"))
 })
 
 test_that("fingerprinting works for edge cases", {
@@ -43,7 +43,7 @@ test_that("fingerprinting works for edge cases", {
   }
   globalassign("readFingerprintTest")
   expect_silent({fp <- madrat:::fingerprint("readFingerprintTest", packages = getConfig("packages"), details = TRUE)})
-  expect_identical(attr(fp,"details")[-1], c(readFingerprintTest="b5efba0b","map.csv"="7e76cec7"))
+  expect_identical(attr(fp,"details")[-1], c(readFingerprintTest="b5efba0b","map.csv"="0350ec95"))
   expect_null(madrat:::fingerprintCall("blub"))
 })
 

--- a/tests/testthat/test-readSource.R
+++ b/tests/testthat/test-readSource.R
@@ -77,5 +77,3 @@ test_that("downloadSource works", {
   globalassign("downloadTest")
   expect_warning(downloadSource("Test", overwrite = TRUE), "reserved and will be overwritten")
 })
-
-

--- a/tests/testthat/test-toolAggregate.R
+++ b/tests/testthat/test-toolAggregate.R
@@ -148,7 +148,7 @@ test_that("toolAggregate does not get confused by identical sets", {
 })
 
 test_that("toolAggregate detects inconsistencies in inputs", {
-  expect_error(toolAggregate(pm[1:3,,], map2), "Complete mapping failed.")
+  expect_error(suppressWarnings(toolAggregate(pm[1:3,,], map2)), "Complete mapping failed.")
   expect_error(toolAggregate(pm[1:3,,],map2, from="from", to="to"),"different number of entries")
 })
 


### PR DESCRIPTION
fingerprintFiles now uses the first 300 bytes of file content and the file's size for creating a fingerprint