### PR TITLE
Optional filename tag for retrieveData

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '206497024'
+ValidationKey: '206669080'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '206467261'
+ValidationKey: '206636020'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "1.101.2",
+  "version": "1.102.0",
   "description": "<p>Provides a framework which should improve reproducibility and transparency in data processing. It provides functionality such as automatic meta data creation and management, rudimentary quality management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this package to deliver everything what is needed to achieve full reproducibility and transparency, but we believe that it supports efforts in this direction.<\/p>",
   "creators": [
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "1.101.1",
+  "version": "1.102.0",
   "description": "<p>Provides a framework which should improve reproducibility and transparency in data processing. It provides functionality such as automatic meta data creation and management, rudimentary quality management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this package to deliver everything what is needed to achieve full reproducibility and transparency, but we believe that it supports efforts in this direction.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 1.101.1
+Version: 1.102.0
 Date: 2021-05-04
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 1.101.2
-Date: 2021-05-05
+Version: 1.102.0
+Date: 2021-05-07
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
              person("Stephen", "Wirth", email = "wirth@pik-potsdam.de", role = "aut"),

--- a/R/fullEXAMPLE.R
+++ b/R/fullEXAMPLE.R
@@ -28,6 +28,6 @@ fullEXAMPLE <- function(rev = 0, dev = "") {
   if (dev == "test") {
     message("Here you could execute code for a hypothetical development version called \"test\"")
   }
-  # return is not required, but can be used to append a tag to the resulting file
+  # return is not required, but can be used to append a tag to the resulting filename
   return(list(tag = "customizable_tag"))
 }

--- a/R/fullEXAMPLE.R
+++ b/R/fullEXAMPLE.R
@@ -1,8 +1,8 @@
 #' fullExample
-#' 
+#'
 #' Example for class of fullX functions. Can be used as template for a new function
 #' or for testing the basic functionality
-#' 
+#'
 #' @param rev data revision which should be used/produced. Format must be compatible to
 #' \code{\link[base]{numeric_version}}.
 #' @param dev development suffix to distinguish development versions for the same data
@@ -13,16 +13,19 @@
 #' @seealso
 #' \code{\link{readSource}},\code{\link{getCalculations}},\code{\link{calcOutput}},\code{\link{setConfig}}
 #' @examples
-#' 
-#' \dontrun{ 
-#' retrieveData("example", rev="2.1.2", dev="test", regionmapping="regionmappingH12.csv")
+#' \dontrun{
+#' retrieveData("example", rev = "2.1.2", dev = "test", regionmapping = "regionmappingH12.csv")
 #' }
-#' 
-fullEXAMPLE <- function(rev=0, dev="") {
-  #ATTENTION: name of the model in function name must be in capital letters!
-  
-  writeLines("This is a test",paste0(getConfig("outputfolder"),"/test.txt"))
+#'
+fullEXAMPLE <- function(rev = 0, dev = "") {
+  # ATTENTION: name of the model in function name must be in capital letters!
 
-  if(rev>=1) calcOutput("TauTotal", years=1995, round=2, file="fm_tau1995.cs4")
-  if(dev=="test") message("Here you could execute code for a hypothetical development version called \"test\"")
+  writeLines("This is a test", paste0(getConfig("outputfolder"), "/test.txt"))
+
+  if (rev >= 1) {
+    calcOutput("TauTotal", years = 1995, round = 2, file = "fm_tau1995.cs4")
+  }
+  if (dev == "test") {
+    message("Here you could execute code for a hypothetical development version called \"test\"")
+  }
 }

--- a/R/fullEXAMPLE.R
+++ b/R/fullEXAMPLE.R
@@ -28,4 +28,6 @@ fullEXAMPLE <- function(rev = 0, dev = "") {
   if (dev == "test") {
     message("Here you could execute code for a hypothetical development version called \"test\"")
   }
+  # return is not required, but can be used to append a tag to the resulting file
+  return(list(tag = "customizable_tag"))
 }

--- a/R/retrieveData.R
+++ b/R/retrieveData.R
@@ -1,9 +1,9 @@
 #' retrieveData
-#' 
+#'
 #' Function to retrieve a predefined collection of calculations for a specific
-#' regionmapping. 
-#' 
-#' 
+#' regionmapping.
+#'
+#'
 #' @param model The names of the model for which the data should be provided
 #' (e.g. "magpie").
 #' @param rev data revision which should be used/produced. Format must be compatible to
@@ -11,122 +11,150 @@
 #' @param dev development suffix to distinguish development versions for the same data
 #' revision. This can be useful to distinguish parallel lines of development.
 #' @param cachetype defines what cache should be used. "rev" points to a cache
-#' shared by all calculations for the given revision and sets forcecache to TRUE, 
+#' shared by all calculations for the given revision and sets forcecache to TRUE,
 #' "def" points to the cache as defined in the current settings and does not change
 #' forcecache setting.
-#' @param ... (Optional) Settings that should be changed using \code{setConfig} 
-#' (e.g. regionmapping). or arguments which should be forwared to the corresponding 
-#' fullXYZ function (Please make sure that argument names in full functions do not 
+#' @param ... (Optional) Settings that should be changed using \code{setConfig}
+#' (e.g. regionmapping). or arguments which should be forwarded to the corresponding
+#' fullXYZ function (Please make sure that argument names in full functions do not
 #' match settings in \code{setConfig}!)
 #' @author Jan Philipp Dietrich, Lavinia Baumstark
 #' @seealso
 #' \code{\link{calcOutput}},\code{\link{setConfig}}
 #' @examples
-#' 
-#' \dontrun{ 
-#' retrieveData("example", rev="2.1.1", dev="test", regionmapping="regionmappingH12.csv")
+#' \dontrun{
+#' retrieveData("example", rev = "2.1.1", dev = "test", regionmapping = "regionmappingH12.csv")
 #' }
 #' @importFrom methods formalArgs
 #' @export
-retrieveData <- function(model, rev=0, dev="", cachetype="rev", ...) {
+retrieveData <- function(model, rev = 0, dev = "", cachetype = "rev", ...) {
+  if (!(cachetype %in% c("rev", "def"))) {
+    stop("Unknown cachetype \"", cachetype, "\"!")
+  }
 
- if (!(cachetype %in% c("rev","def"))) stop("Unknown cachetype \"",cachetype,"\"!")
-   
- # extract setConfig settings and apply via setConfig
- inargs <- list(...)
- tmp <- intersect(names(inargs),formalArgs(setConfig))
- if (length(tmp) > 0) do.call(setConfig,inargs[tmp])
- 
- #receive function name and function
- functionname <- prepFunctionName(type=toupper(model), prefix="full")
- functiononly <- eval(parse(text=sub("\\(.*$","",functionname)))
- 
- # are all arguments used somewhere? -> error
- tmp <- (names(inargs) %in% union(formalArgs(setConfig),formalArgs(functiononly)))
- if(!all(tmp)) stop("Unknown argument(s) \"", paste(names(inargs)[!tmp],collapse="\", \""),"\"")
- 
- # are arguments used in both - setConfig and the fullFunction? -> warning
- tmp <- intersect(formalArgs(setConfig), formalArgs(functiononly))
- if(length(tmp)>0) warning("Overlapping arguments between setConfig and retrieve function (\"",paste(tmp, collapse="\", \""),"\")")
- 
- uselabels <- !(isTRUE(getConfig("nolabels")) || model %in% getConfig("nolabels"))
- 
- # reduce inargs to arguments sent to full function and create hash from it
- inargs <- inargs[names(inargs) %in% formalArgs(functiononly)]
- # insert default arguments, if not set explicitly to ensure identical args_hash
- defargs <- formals(functiononly)
- # remove dev and rev arguments as they are being treated separately
- defargs$dev <- NULL
- defargs$rev <- NULL
- toadd <- names(defargs)[!(names(defargs)%in%names(inargs))]
- if (length(toadd) > 0) inargs[toadd] <- defargs[toadd]
- if (length(inargs) > 0) {
-   hashs <- digest(inargs, algo = getConfig("hash"))
-   if (uselabels) hashs <- toolCodeLabels(hashs)
-   args_hash <- paste0(hashs,"_")
- } else args_hash <- NULL
+  # extract setConfig settings and apply via setConfig
+  inargs <- list(...)
+  tmp <- intersect(names(inargs), formalArgs(setConfig))
+  if (length(tmp) > 0) {
+    do.call(setConfig, inargs[tmp])
+  }
 
- regionmapping <- getConfig("regionmapping")  
- if (!file.exists(regionmapping)) regionmapping <- toolGetMapping(regionmapping, type = "regional", returnPathOnly = TRUE)
- regionscode <- regionscode(regionmapping, label = uselabels) 
- 
- # save current settings to set back if needed
- cfg_backup <- getOption("madrat_cfg")
- on.exit(options("madrat_cfg" = cfg_backup))
+  # receive function name and function
+  functionname <- prepFunctionName(type = toupper(model), prefix = "full")
+  functiononly <- eval(parse(text = sub("\\(.*$", "", functionname)))
 
- rev <- numeric_version(rev)
- 
- collectionname <- paste0("rev", rev, dev, "_", regionscode, "_", args_hash, tolower(model), ifelse(getConfig("debug")==TRUE,"_debug",""))
- sourcefolder <- paste0(getConfig("outputfolder"), "/", collectionname)
- if(!file.exists(paste0(sourcefolder,".tgz")) || getConfig("debug")==TRUE) {
-   # data not yet ready and has to be prepared first
-   
-   #create folder if required
-   if (!file.exists(sourcefolder)) dir.create(sourcefolder,recursive = TRUE)
-   
-   #copy mapping to mapping folder and set config accordingly
-   mappath <- toolGetMapping(paste0(regionscode,".csv"), "regional", error.missing = FALSE, returnPathOnly = TRUE)
-   if (!file.exists(mappath)) {
-      if (!dir.exists(dirname(mappath))) dir.create(dirname(mappath), recursive = TRUE)
-      file.copy(regionmapping,mappath)
-   }
-   #copy mapping to output folder
-   try(file.copy(regionmapping, sourcefolder, overwrite = TRUE))
-   setConfig(regionmapping = paste0(regionscode,".csv"),
-             outputfolder = sourcefolder,
-             diagnostics = "diagnostics")
-   
-   if (cachetype == "rev") {
-      setConfig(cachefolder = paste0(getConfig("mainfolder"),"/cache/rev",rev,dev),
+  # are all arguments used somewhere? -> error
+  tmp <- (names(inargs) %in% union(formalArgs(setConfig), formalArgs(functiononly)))
+  if (!all(tmp)) {
+    stop("Unknown argument(s) \"", paste(names(inargs)[!tmp], collapse = "\", \""), "\"")
+  }
+
+  # are arguments used in both - setConfig and the fullFunction? -> warning
+  tmp <- intersect(formalArgs(setConfig), formalArgs(functiononly))
+  if (length(tmp) > 0) {
+    warning(
+      "Overlapping arguments between setConfig and retrieve function (\"",
+      paste(tmp, collapse = "\", \""), "\")"
+    )
+  }
+
+  uselabels <- !(isTRUE(getConfig("nolabels")) || model %in% getConfig("nolabels"))
+
+  # reduce inargs to arguments sent to full function and create hash from it
+  inargs <- inargs[names(inargs) %in% formalArgs(functiononly)]
+  # insert default arguments, if not set explicitly to ensure identical args_hash
+  defargs <- formals(functiononly)
+  # remove dev and rev arguments as they are being treated separately
+  defargs$dev <- NULL
+  defargs$rev <- NULL
+  toadd <- names(defargs)[!(names(defargs) %in% names(inargs))]
+  if (length(toadd) > 0) {
+    inargs[toadd] <- defargs[toadd]
+  }
+  if (length(inargs) > 0) {
+    hashs <- digest(inargs, algo = getConfig("hash"))
+    if (uselabels) {
+      hashs <- toolCodeLabels(hashs)
+    }
+    argsHash <- paste0(hashs, "_")
+  } else {
+    argsHash <- NULL
+  }
+
+  regionmapping <- getConfig("regionmapping")
+  if (!file.exists(regionmapping)) {
+    regionmapping <- toolGetMapping(regionmapping, type = "regional", returnPathOnly = TRUE)
+  }
+  regionscode <- regionscode(regionmapping, label = uselabels)
+
+  # save current settings to set back if needed
+  cfgBackup <- getOption("madrat_cfg")
+  on.exit(options("madrat_cfg" = cfgBackup))
+
+  rev <- numeric_version(rev)
+
+  collectionname <- paste0(
+    "rev", rev, dev, "_", regionscode, "_", argsHash, tolower(model),
+    ifelse(getConfig("debug") == TRUE, "_debug", "")
+  )
+  sourcefolder <- paste0(getConfig("outputfolder"), "/", collectionname)
+  if (!file.exists(paste0(sourcefolder, ".tgz")) || getConfig("debug") == TRUE) {
+    # data not yet ready and has to be prepared first
+
+    # create folder if required
+    if (!file.exists(sourcefolder)) {
+      dir.create(sourcefolder, recursive = TRUE)
+    }
+
+    # copy mapping to mapping folder and set config accordingly
+    mappath <- toolGetMapping(paste0(regionscode, ".csv"), "regional", error.missing = FALSE, returnPathOnly = TRUE)
+    if (!file.exists(mappath)) {
+      if (!dir.exists(dirname(mappath))) {
+        dir.create(dirname(mappath), recursive = TRUE)
+      }
+      file.copy(regionmapping, mappath)
+    }
+    # copy mapping to output folder
+    try(file.copy(regionmapping, sourcefolder, overwrite = TRUE))
+    setConfig(
+      regionmapping = paste0(regionscode, ".csv"),
+      outputfolder = sourcefolder,
+      diagnostics = "diagnostics"
+    )
+
+    if (cachetype == "rev") {
+      setConfig(cachefolder = paste0(getConfig("mainfolder"), "/cache/rev", rev, dev),
                 forcecache = TRUE)
-   } 
-   
-   getConfig(print = TRUE)
+    }
 
-   # run full* functions
-   startinfo <- toolstartmessage(0)
-    
-   vcat(2," - execute function ",functionname, fill=300, show_prefix=FALSE)
-   
-   # add rev and dev arguments
-   inargs$rev <- rev
-   inargs$dev <- dev
-   
-   args <- as.list(formals(functiononly))
-   for(n in names(args)) {
-      if(n %in% names(inargs)) args[[n]] <- inargs[[n]]
-   }
-   x <- do.call(functiononly,args)
-   vcat(2," - function ",functionname," finished", fill=300, show_prefix=FALSE)   
-   
-   cwd <- getwd()
-   setwd(sourcefolder)
-   trash <- system(paste0("tar -czf ../",collectionname,".tgz"," *"), intern = TRUE)
-   setwd(cwd) 
-   unlink(sourcefolder, recursive = TRUE)
- } else {
-  startinfo <- toolstartmessage(0)
-  vcat(-2," - data is already available and not calculated again.", fill = 300) 
- }  
- toolendmessage(startinfo)
+    getConfig(print = TRUE)
+
+    # run full* functions
+    startinfo <- toolstartmessage(0)
+
+    vcat(2, " - execute function ", functionname, fill = 300, show_prefix = FALSE)
+
+    # add rev and dev arguments
+    inargs$rev <- rev
+    inargs$dev <- dev
+
+    args <- as.list(formals(functiononly))
+    for (n in names(args)) {
+      if (n %in% names(inargs)) {
+        args[[n]] <- inargs[[n]]
+      }
+    }
+    do.call(functiononly, args)
+    vcat(2, " - function ", functionname, " finished", fill = 300, show_prefix = FALSE)
+
+    cwd <- getwd()
+    setwd(sourcefolder)
+    system(paste0("tar -czf ../", collectionname, ".tgz", " *"), intern = TRUE)
+    setwd(cwd)
+    unlink(sourcefolder, recursive = TRUE)
+  } else {
+    startinfo <- toolstartmessage(0)
+    vcat(-2, " - data is already available and not calculated again.", fill = 300)
+  }
+  toolendmessage(startinfo)
 }

--- a/R/toolMappingFile.R
+++ b/R/toolMappingFile.R
@@ -1,6 +1,6 @@
 #' Tool: MappingFile
 #' 
-#' Functions which calculates the path to a mapping file
+#' Function which calculates the path to a mapping file
 #' 
 #' 
 #' @param type Mapping type ("regional", or "sectoral")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **1.101.2**
+R package **madrat**, version **1.102.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490)  [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/madrat)
 
@@ -48,11 +48,9 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky
-B, Kreidenweis U, Klein D, Führlich P (2021). _madrat: May All Data be
-Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490
-(URL: https://doi.org/10.5281/zenodo.1115490), R package version
-1.101.2, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2021). _madrat:
+May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL:
+https://doi.org/10.5281/zenodo.1115490), R package version 1.102.0, <URL: https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -61,7 +59,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2021},
-  note = {R package version 1.101.2},
+  note = {R package version 1.102.0},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **1.101.1**
+R package **madrat**, version **1.102.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490)  [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/madrat)
 
@@ -36,7 +36,7 @@ update.packages()
 The package comes with vignettes describing the basic functionality of the package and how to use it. You can load them with the following command (the package needs to be installed):
 
 ```r
-vignette("madrat-caching") # Data caching in MADRaT
+vignette("madrat-caching") # Data caching in madrat
 vignette("madrat")         # Data preparation with madrat
 ```
 
@@ -48,11 +48,9 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B,
-Kreidenweis U, Klein D, Führlich P (2021). _madrat: May All Data be Reproducible
-and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL:
-https://doi.org/10.5281/zenodo.1115490), R package version 1.101.1, <URL:
-https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P
+(2021). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL:
+https://doi.org/10.5281/zenodo.1115490), R package version 1.102.0, <URL: https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -61,7 +59,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2021},
-  note = {R package version 1.101.1},
+  note = {R package version 1.102.0},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/tests/testthat/test-retrieveData.R
+++ b/tests/testthat/test-retrieveData.R
@@ -45,3 +45,11 @@ test_that("retrieveData works if no tag is returned", {
   expect_message(retrieveData("Testtwo", globalenv = TRUE), "Run retrieveData")
   expect_true(file.exists(paste0(getConfig("outputfolder"), "/rev0_h12_testtwo.tgz")))
 })
+
+test_that("retrieveData warns on regex characters in model name", {
+  fullMODEL.REGEX <- function() {
+  }
+  globalassign("fullMODEL.REGEX")
+
+  expect_warning(retrieveData("MODEL.REGEX", globalenv = TRUE), "At least one of the regex characters")
+})

--- a/tests/testthat/test-retrieveData.R
+++ b/tests/testthat/test-retrieveData.R
@@ -1,16 +1,11 @@
-context("retrieveData")
-
 globalassign <- function(...) {
   for (x in c(...)) assign(x, eval.parent(parse(text = x)), .GlobalEnv)
 }
 
 
 test_that("retrieveData works as expected", {
-  ofolder <- paste0(tempdir(), "/output")
-  unlink(ofolder, recursive = TRUE)
-  setConfig(outputfolder = ofolder, verbosity = 2, .verbose = FALSE)
-  expect_message(retrieveData("example", rev = 0, dev = "test"), "execute function")
-  expect_true(file.exists(paste0(getConfig("outputfolder"), "/rev0test_h12_example.tgz")))
+  expect_message(retrieveData("example", rev = 0, dev = "test"), "Run retrieveData")
+  expect_true(file.exists(paste0(getConfig("outputfolder"), "/rev0test_h12_example_customizable_tag.tgz")))
   expect_message(retrieveData("example", rev = 0, dev = "test"), "data is already available")
 })
 
@@ -30,4 +25,23 @@ test_that("argument handling works", {
   expect_error(retrieveData("Test"), "is not a valid output type")
   expect_warning(retrieveData("Test", globalenv = TRUE), "Overlapping arguments")
   expect_message(suppressWarnings(retrieveData("Test", myargument = "hello")), "myargument = hello")
+})
+
+test_that("a tag can be appended to filename", {
+  fullTEST <- function() {
+    return(list(tag = "some_tag"))
+  }
+  globalassign("fullTEST")
+
+  expect_message(retrieveData("Test", globalenv = TRUE), "Run retrieveData")
+  expect_true(file.exists(paste0(getConfig("outputfolder"), "/rev0_h12_test_some_tag.tgz")))
+})
+
+test_that("retrieveData works if no tag is returned", {
+  fullTESTTWO <- function() {
+  }
+  globalassign("fullTESTTWO")
+
+  expect_message(retrieveData("Testtwo", globalenv = TRUE), "Run retrieveData")
+  expect_true(file.exists(paste0(getConfig("outputfolder"), "/rev0_h12_testtwo.tgz")))
 })

--- a/tests/testthat/test-retrieveData.R
+++ b/tests/testthat/test-retrieveData.R
@@ -1,34 +1,33 @@
 context("retrieveData")
 
 globalassign <- function(...) {
-  for (x in c(...)) assign(x,eval.parent(parse(text = x)),.GlobalEnv)
+  for (x in c(...)) assign(x, eval.parent(parse(text = x)), .GlobalEnv)
 }
 
 
 test_that("retrieveData works as expected", {
-  ofolder <- paste0(tempdir(),"/output")
+  ofolder <- paste0(tempdir(), "/output")
   unlink(ofolder, recursive = TRUE)
   setConfig(outputfolder = ofolder, verbosity = 2, .verbose = FALSE)
   expect_message(retrieveData("example", rev = 0, dev = "test"), "execute function")
-  expect_true(file.exists(paste0(getConfig("outputfolder"),"/rev0test_h12_example.tgz")))
+  expect_true(file.exists(paste0(getConfig("outputfolder"), "/rev0test_h12_example.tgz")))
   expect_message(retrieveData("example", rev = 0, dev = "test"), "data is already available")
 })
 
 test_that("retrieveData properly detects malformed inputs", {
   expect_error(retrieveData("NotThere"), "is not a valid output type")
-  expect_error(retrieveData("Example", cachetype="fantasy"), "Unknown cachetype")
-  expect_error(retrieveData("Example", unknownargument=42), "Unknown argument")
-})  
-  
-test_that("argument handling works", {  
-  fullTEST <- function(rev, myargument = NULL, forcecache=12) {
-    if(!is.null(myargument)) message("myargument = ", myargument)
+  expect_error(retrieveData("Example", cachetype = "fantasy"), "Unknown cachetype")
+  expect_error(retrieveData("Example", unknownargument = 42), "Unknown argument")
+})
+
+test_that("argument handling works", {
+  fullTEST <- function(rev, myargument = NULL, forcecache = 12) {
+    if (!is.null(myargument)) message("myargument = ", myargument)
     return()
   }
   globalassign("fullTEST")
   setConfig(globalenv = FALSE, .verbose = FALSE)
   expect_error(retrieveData("Test"), "is not a valid output type")
   expect_warning(retrieveData("Test", globalenv = TRUE), "Overlapping arguments")
-  expect_message(suppressWarnings(retrieveData("Test", myargument="hello")), "myargument = hello")
+  expect_message(suppressWarnings(retrieveData("Test", myargument = "hello")), "myargument = hello")
 })
-  

--- a/vignettes/madrat-caching.Rmd
+++ b/vignettes/madrat-caching.Rmd
@@ -1,10 +1,10 @@
 ---
-title: "Data caching in MADRaT"
+title: "Data caching in madrat"
 author: "Jan Philipp Dietrich"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Data caching in MADRaT}
+  %\VignetteIndexEntry{Data caching in madrat}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -13,7 +13,7 @@ vignette: >
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
 ```
 
-A central feature of the MADRaT framework is its ability to load data from cache rather than recompute it when the calculation have run already before. Here, we explain what user should know about the caching to avoid unwanted behavior.
+A central feature of the madrat framework is its ability to load data from cache rather than recompute it when the calculation have run already before. Here, we explain what user should know about the caching to avoid unwanted behavior.
 
 ## Basics
 
@@ -29,9 +29,9 @@ With `cachetype = "rev"` `retrieveData` will create a new, revision-specific cac
 
 ## Fingerprint
 
-In order to estimate whether a calculation should be rerun or whether the data can be read from cache MADRaT creates fingerprints for each function. If the fingerprint of the current function call agrees with the fingerprint of the corresponding cache file the cache is assumed up-to-date and read in. If they disagree, the cache file is assumed to be potentially outdated and ignored (except for `forcecache = TRUE` in which case it would be read in anyways).
+In order to estimate whether a calculation should be rerun or whether the data can be read from cache madrat creates fingerprints for each function. If the fingerprint of the current function call agrees with the fingerprint of the corresponding cache file the cache is assumed up-to-date and read in. If they disagree, the cache file is assumed to be potentially outdated and ignored (except for `forcecache = TRUE` in which case it would be read in anyways).
 
-The fingerpint is created by looking at the dependency graph of a function which can be retrieved via `getDependencies`:
+The fingerprint is created by looking at the dependency graph of a function which can be retrieved via `getDependencies`:
 
 ```{r, echo = TRUE, eval=TRUE}
 getDependencies("calcTauTotal")
@@ -53,7 +53,7 @@ On the other hand, the dependency graph might also include dependencies which on
 
 ## Customize fingerprinting
 
-To make sure that the fingerprint is appropriatly reflecting the current status of a calculation there are a few possibilities to steer its behavior:
+To make sure that the fingerprint is appropriately reflecting the current status of a calculation there are a few possibilities to steer its behavior:
 
 1. Use madrat-style functions for all calculation that should get monitored by the fingerprinting algorithm (e.g. if part of the calculation is outsourced, call this new function `tool..` to have it monitored.)
 
@@ -96,7 +96,7 @@ In this example are two source data sets and two calculation functions. `calcExa
   fp2 <- madrat:::fingerprint("calcExample2", details = TRUE)
 ```
 
-Looking at the fingerprints this is reflected in the hash components of each fingerprint (please NOTE that the source folders are not hashed in this example as they do not exist yet. If they exist they would show up here as well as hash components). One can see, that the hash for `readData` is the same in bothe fingerprints but as the other hashs differ also the resulting fingerprint for bothe calculations is different.
+Looking at the fingerprints this is reflected in the hash components of each fingerprint (please NOTE that the source folders are not hashed in this example as they do not exist yet. If they exist they would show up here as well as hash components). One can see, that the hash for `readData` is the same in both fingerprints but as the other hashes differ also the resulting fingerprint for both calculations is different.
 
 ```{r, echo = TRUE, eval=TRUE}
   readData <- function() return(99)


### PR DESCRIPTION
I applied some auto-formatting, so if actual changes are hard to see only look at commits after the initial formatting.
fullXYZ functions may now `return(list(tag = "mytag"))`, which will result in a filename like rev0_h12_test_mytag.tgz (with mytag as suffix)