### PR TITLE
Bugfix sort encoding

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '206921655'
+ValidationKey: '206951448'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '206902890'
+ValidationKey: '206921655'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "1.102.7",
+  "version": "1.102.8",
   "description": "<p>Provides a framework which should improve reproducibility and transparency in data processing. It provides functionality such as automatic meta data creation and management, rudimentary quality management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this package to deliver everything what is needed to achieve full reproducibility and transparency, but we believe that it supports efforts in this direction.<\/p>",
   "creators": [
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "1.102.6",
+  "version": "1.102.7",
   "description": "<p>Provides a framework which should improve reproducibility and transparency in data processing. It provides functionality such as automatic meta data creation and management, rudimentary quality management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this package to deliver everything what is needed to achieve full reproducibility and transparency, but we believe that it supports efforts in this direction.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 1.102.7
+Version: 1.102.8
 Date: 2021-05-19
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 1.102.6
+Version: 1.102.7
 Date: 2021-05-18
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),

--- a/R/cacheArgumentsHash.R
+++ b/R/cacheArgumentsHash.R
@@ -37,7 +37,9 @@ cacheArgumentsHash <- function(call, args=NULL) {
     if (identical(defargs[[i]], args[[i]])) args <- args[names(args) != i]
   }
   if (length(args) == 0) return(NULL)
-  if (!is.null(args)) args <- paste0("-",digest(args[order(names(args), method = "radix")], algo = getConfig("hash")))
+  if (!is.null(args)) {
+    args <- paste0("-", digest(args[robustOrder(names(args))], algo = getConfig("hash")))
+  }
   return(args)
 }
 

--- a/R/cacheName.R
+++ b/R/cacheName.R
@@ -76,7 +76,7 @@ cacheName <- function(prefix, type, args=NULL,  graph=NULL, mode="put", packages
     return(NULL)
   }
   if (length(files) == 1) file <- files
-  else file <- files[order(file.mtime(files), decreasing = TRUE)][1]
+  else file <- files[robustOrder(file.mtime(files), decreasing = TRUE)][1]
   vcat(1," - forced cache does not match fingerprint ", fp, 
        fill = 300, show_prefix = FALSE)
   return(file)

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -158,11 +158,11 @@ calcOutput <- function(type,aggregate=TRUE,file=NULL,years=NULL,round=NULL,suppl
     if(x$isocountries) {
       datacountries <- 
       .countrycheck <- function(datacountries, name){
-        datacountries <- sort(datacountries)
+        datacountries <- robustSort(datacountries)
         iso_country <- read.csv2(system.file("extdata","iso_country.csv",package = "madrat"),row.names=NULL)
         iso_country1<-as.vector(iso_country[,"x"])
         names(iso_country1)<-iso_country[,"X"]
-        isocountries <- sort(iso_country1)
+        isocountries <- robustSort(iso_country1)
         if(length(isocountries)!=length(datacountries)) stop("Wrong number of countries in ",name," returned by ",functionname,"!")
         if(any(isocountries!=datacountries)) stop("Countries in ",name," returned by ",functionname," do not agree with iso country list!")
       }

--- a/R/findBottlenecks.R
+++ b/R/findBottlenecks.R
@@ -70,7 +70,7 @@ findBottlenecks <- function(file, unit="min", cumulative=TRUE) {
   message("Total runtime: ", th, " hours ", tmin, " minutes ",ts," seconds")
   x$"time[%]" <- round(x$"time[s]"/totalruntime*100,2)
   x$"net[%]" <- round(x$"net[s]"/totalruntime*100,2)
-  x <- x[order(x$"net[s]", decreasing = TRUE),]
+  x <- x[robustOrder(x$"net[s]", decreasing = TRUE),]
   
   if (unit %in% c("min","h")) {
     x$"time[s]" <- NULL

--- a/R/fingerprint.R
+++ b/R/fingerprint.R
@@ -37,11 +37,11 @@ fingerprint <- function(name, details=FALSE, graph = NULL, ...) {
   result <- tryCatch({
     dependencies <- getDependencies(name, direction = "in", self = TRUE, graph = graph, ...)
 
-    fingerprintFunctions <- dependencies$hash[order(dependencies$call)]
-    names(fingerprintFunctions) <- dependencies$call[order(dependencies$call)]
+    fingerprintFunctions <- dependencies$hash[robustOrder(dependencies$call)]
+    names(fingerprintFunctions) <- dependencies$call[robustOrder(dependencies$call)]
 
     # handle special requests via flags
-    .tmp <- function(x) return(sort(sub(":+", ":::", x), method = "radix"))
+    .tmp <- function(x) return(robustSort(sub(":+", ":::", x)))
     ignore  <- .tmp(attr(dependencies, "flags")$ignore)
     monitor <- .tmp(attr(dependencies, "flags")$monitor)
     # if conflicting information is giving (monitor and ignore at the same time,
@@ -53,12 +53,12 @@ fingerprint <- function(name, details=FALSE, graph = NULL, ...) {
     fingerprintFunctions <- fingerprintFunctions[setdiff(names(fingerprintFunctions), ignore)]
     sources <- substring(dependencies$func[dependencies$type == "read"], 5)
     if (length(sources) > 0) {
-      sources <- paste0(getConfig("sourcefolder"), "/", sort(sources, method = "radix"))
+      sources <- paste0(getConfig("sourcefolder"), "/", robustSort(sources))
     }
     fingerprintSources <- fingerprintFiles(sources)
     fingerprintMappings <- fingerprintFiles(attr(dependencies, "mappings"))
     fingerprint <- c(fingerprintFunctions, fingerprintSources, fingerprintMappings, fingerprintMonitored)
-    fingerprint <- fingerprint[order(basename(names(fingerprint)), method = "radix")]
+    fingerprint <- fingerprint[robustOrder(basename(names(fingerprint)))]
     out <- digest(unname(fingerprint), algo = getConfig("hash"))
     attr(out, "call") <- dependencies$call[dependencies$func == name]
     if (details) {
@@ -91,7 +91,7 @@ fingerprintFiles <- function(paths) {
   if (length(paths) == 0) return(NULL)
   .tmp <- function(path) {
     if (dir.exists(path)) {
-      filenames <- sort(list.files(path, recursive = TRUE, full.names = TRUE), method = "radix")
+      filenames <- robustSort(list.files(path, recursive = TRUE, full.names = TRUE))
     } else {
       filenames <- path
     }

--- a/R/getDependencies.R
+++ b/R/getDependencies.R
@@ -34,7 +34,7 @@ getDependencies <- function(name, direction="in", graph=NULL, type=NULL, self=FA
   .filterList <- function(l, calls, owncall, aggregate="monitor") {
     # in case of aggregate, aggregate list entries over all calls
     # otherwise only take entries from current call
-    .tmp <- function(x,filter) return(sort(unique(unlist(x[filter]))))
+    .tmp <- function(x,filter) return(robustSort(unique(unlist(x[filter]))))
     aggr <- (names(l) %in% aggregate)
     out  <- l
     out[aggr] <- lapply(l[aggr], .tmp, filter = union(owncall,calls))
@@ -54,7 +54,7 @@ getDependencies <- function(name, direction="in", graph=NULL, type=NULL, self=FA
                       call = owncall,
                       hash = attr(graph, "hash")[fpool$call[fpool$shortcall == name]],
                       row.names = NULL, stringsAsFactors = FALSE)
-    attr(out, "mappings") <- sort(unique(unlist(attr(graph,"mappings")[out$call])))
+    attr(out, "mappings") <- robustSort(unique(unlist(attr(graph,"mappings")[out$call])))
     attr(out, "flags") <- .filterList(attr(graph,"flags"), owncall, owncall)
     return(out)
   }
@@ -64,9 +64,9 @@ getDependencies <- function(name, direction="in", graph=NULL, type=NULL, self=FA
     tmp <- unique(c(attr(igraph::subcomponent(ggraph,name,"in"),"names"),
                     attr(igraph::subcomponent(ggraph,name,"out"),"names")))
   } else if(direction=="dout") {
-    tmp <- sort(unique(graph$to[graph$from==name]))
+    tmp <- robustSort(unique(graph$to[graph$from==name]))
   } else if(direction=="din") {
-    tmp <- sort(unique(graph$from[graph$to==name]))
+    tmp <- robustSort(unique(graph$from[graph$to==name]))
   } else {
     tmp <- attr(igraph::subcomponent(ggraph,name,direction),"names")
   }
@@ -77,10 +77,10 @@ getDependencies <- function(name, direction="in", graph=NULL, type=NULL, self=FA
   out$call[out$package == ".GlobalEnv"] <- out$func[out$package == ".GlobalEnv"]
   out$hash <- attr(graph, "hash")[out$call]
   if (!is.null(type)) out <- out[out$type %in% type,]
-  out <- out[order(out$package),]
-  out <- out[order(out$type),]
+  out <- out[robustOrder(out$package),]
+  out <- out[robustOrder(out$type),]
   out <- data.frame(out ,row.names = NULL, stringsAsFactors = FALSE)
-  attr(out, "mappings") <- sort(unique(unlist(attr(graph,"mappings")[out$call])))
+  attr(out, "mappings") <- robustSort(unique(unlist(attr(graph,"mappings")[out$call])))
   attr(out, "flags") <- .filterList(attr(graph,"flags"), out$call, owncall)
   return(out)
 }

--- a/R/getISOlist.R
+++ b/R/getISOlist.R
@@ -25,7 +25,7 @@ getISOlist <- function(type="all") {
   iso_country <- read.csv2(system.file("extdata","iso_country.csv",package = "madrat"), row.names = NULL)
   iso_country1 <- as.vector(iso_country[,"x"])
   names(iso_country1) <- iso_country[,"X"]
-  ref <- sort(iso_country1)
+  ref <- robustSort(iso_country1)
   if (type == "all") return(ref)
   
   pop2015 <- read.magpie(system.file("extdata","pop2015.csv",package = "madrat"))

--- a/R/getMadratGraph.R
+++ b/R/getMadratGraph.R
@@ -26,7 +26,7 @@ getMadratGraph <- function(packages=installedMadratUniverse(), globalenv=getConf
       if (length(f) > 0)  globalenv <- sapply(mget(f, envir = .GlobalEnv),deparse)
       else globalenv <- FALSE
     }
-    return(paste0("GH",digest(c(mtimes,sort(packages),globalenv), algo = getConfig("hash"))))
+    return(paste0("GH", digest(c(mtimes, robustSort(packages), globalenv), algo = getConfig("hash"))))
   }
   
   gHash <- .graphHash(packages,globalenv)

--- a/R/getMadratInfo.R
+++ b/R/getMadratInfo.R
@@ -72,7 +72,7 @@ getMadratInfo <- function(graph=NULL, cutoff=5, extended=FALSE, ...) {
   .checkBidirectional(graph, details = TRUE, cutoff = cutoff)
   
   message("\n.:: Check for read/calc calls in tool functions ::.")
-  tmp <- sort(unique(graph[grepl("^tool",graph$to) & !grepl("^tool",graph$from),"to"]))
+  tmp <- robustSort(unique(graph[grepl("^tool",graph$to) & !grepl("^tool",graph$from),"to"]))
   if(length(tmp)>0) {
     warning("Some tool functions contain read or calc statements! Check report for more info!")
     message("[warning]\n[warning] Following tool function contain either read or calc calls: \n[warning]   ",
@@ -141,7 +141,7 @@ getMadratInfo <- function(graph=NULL, cutoff=5, extended=FALSE, ...) {
     
   for(f in fulls) {
     tmp <- singleuse[singleuse$callfunc==f,2:3]
-    tmp <- tmp[order(tmp[2],tmp[1]),]
+    tmp <- tmp[robustOrder(tmp[2],tmp[1]),]
     message("[INFO]\n[INFO] .: exclusive calls for ",f," (",dim(tmp)[1]," members) :.")
     out$exclusive_use[[f]] <- tmp 
     if(dim(tmp)[1]>cutoff) tmp <- rbind(tmp[1:cutoff,],c("...","..."))
@@ -150,7 +150,7 @@ getMadratInfo <- function(graph=NULL, cutoff=5, extended=FALSE, ...) {
 
   tmp <- data.frame(as.matrix(attr(graph,"fpool")[,c("fname","package")]), stringsAsFactors = FALSE)
   tmp <- tmp[tmp$fname %in% nouse,]
-  tmp <- tmp[order(tmp[2],tmp[1]),]
+  tmp <- tmp[robustOrder(tmp[2],tmp[1]),]
   message("[INFO]\n[INFO] .: functions with no calls in full-functions (",dim(tmp)[1]," members) :.")
   out$exclusive_use$no_use <- tmp
   if(dim(tmp)[1]>cutoff) tmp <- rbind(tmp[1:cutoff,],c("...","..."))

--- a/R/installedMadratUniverse.R
+++ b/R/installedMadratUniverse.R
@@ -19,5 +19,5 @@
 #' @export
 #' 
 installedMadratUniverse <- function() {
- return(sort(union(getConfig("packages"),grep("^m[rs]", rownames(installed.packages()), value=TRUE))))
+ return(robustSort(union(getConfig("packages"), grep("^m[rs]", rownames(installed.packages()), value = TRUE))))
 }

--- a/R/readSource.R
+++ b/R/readSource.R
@@ -52,8 +52,8 @@ readSource <- function(type,subtype=NULL,convert=TRUE) {
     iso_country  <- read.csv2(system.file("extdata","iso_country.csv",package = "madrat"),row.names=NULL)
     iso_country1 <- as.vector(iso_country[,"x"])
     names(iso_country1) <-iso_country[,"X"]
-    isocountries  <- sort(iso_country1)
-    datacountries <- sort(x)
+    isocountries  <- robustSort(iso_country1)
+    datacountries <- robustSort(x)
     if(length(isocountries)!=length(datacountries)) stop("Wrong number of countries returned by ",functionname,"!")
     if(any(isocountries!=datacountries)) stop("Countries returned by ",functionname," do not agree with iso country list!")
   }

--- a/R/regionscode.R
+++ b/R/regionscode.R
@@ -47,14 +47,14 @@ regionscode <- function(mapping=NULL, label=FALSE, strict=TRUE) {
     iso_country  <- read.csv2(system.file("extdata","iso_country.csv",package = "madrat"), row.names = NULL)
     iso_country1 <- as.vector(iso_country[,"x"])
     names(iso_country1) <- iso_country[,"X"]
-    isocountries <- sort(iso_country1)
+    isocountries <- robustSort(iso_country1)
   
     if (nrow(mapping) > length(isocountries)) stop("Provided regionmapping has more rows than there are ISO countries in the ISO reference list. Please check the mapping!")
     if (nrow(mapping) < length(isocountries)) stop("Provided regionmapping has less rows than there are ISO countries in the ISO reference list. Please check the mapping!")
   
     lists_agree <- NULL
     for (i in 1:ncol(mapping)) {
-      lists_agree <- c(lists_agree,all(isocountries == sort(as.vector(mapping[[i]]))))
+      lists_agree <- c(lists_agree,all(isocountries == robustSort(as.vector(mapping[[i]]))))
     }
   
     if (!any(lists_agree)) stop("Provided regionmapping does not contain a iso country column which agrees with the reference list of ISO countries! Please check the mapping!")
@@ -64,7 +64,7 @@ regionscode <- function(mapping=NULL, label=FALSE, strict=TRUE) {
     
     tmp <- as.vector(mapping[[1]])
     for (i in 2:ncol(mapping)) {
-      tmp <- sort(paste(tmp, as.vector(mapping[[i]]), sep = "."), method = "radix")
+      tmp <- robustSort(paste(tmp, as.vector(mapping[[i]]), sep = "."))
     }
   } else {
     tmp <- mapping

--- a/R/robustOrder.R
+++ b/R/robustOrder.R
@@ -1,0 +1,33 @@
+#' robustOrder, robustSort
+#' 
+#' robustOrder: A wrapper around base::order that always uses the locale independent method = "radix". If the
+#' argument x is a character vector it is converted to utf8 first.
+#' robustSort: A convenience function using order to sort a vector using radix sort. The resulting vector will have the
+#' same encoding as the input although internally character vectors are converted to utf8 before ordering.
+#' 
+#' @param ... One or more vectors of the same length
+#' @param na.last If TRUE missing values are put last, if FALSE they are put first, if NA they are removed
+#' @param decreasing If TRUE decreasing/descending order, if FALSE increasing/ascending order. For the "radix" method,
+#' this can be a vector of length equal to the number of arguments in ... . For the other methods, it must be length one.
+#' @param method Default is "radix", which is locale independent. The alternatives "auto" and "shell" should not be used
+#' in madrat because they are locale dependent.
+#' @seealso \code{\link[base]{order}}
+#' @author Pascal Führlich
+robustOrder <- function(..., na.last = TRUE, decreasing = FALSE, method = "radix") {
+  args <- list(...)
+  if (any(lapply(args, length) == 0)) {
+    return()
+  }
+  args <- lapply(args, sapply, function(element) {
+    ifelse(is.character(element), enc2utf8(element), element)
+  })
+  args <- unname(args)
+  args$na.last <- na.last
+  args$decreasing <- decreasing
+  args$method <- method
+  return(do.call(order, args))
+}
+
+robustSort <- function(x, ...) {
+  return(x[robustOrder(x, ...)])
+}

--- a/R/robustOrder.R
+++ b/R/robustOrder.R
@@ -16,10 +16,13 @@
 robustOrder <- function(..., na.last = TRUE, decreasing = FALSE, method = "radix") {
   args <- list(...)
   if (any(lapply(args, length) == 0)) {
-    return()
+    return(vector(mode = "integer", length = 0))
   }
-  args <- lapply(args, sapply, function(element) {
-    ifelse(is.character(element), enc2utf8(element), element)
+  args <- lapply(args, function(x) {
+    if (is.character(x)) {
+      return(enc2utf8(x))
+    }
+    return(x)
   })
   args <- unname(args)
   args$na.last <- na.last

--- a/R/toolCountryFill.R
+++ b/R/toolCountryFill.R
@@ -111,7 +111,7 @@ toolCountryFill <- function(x,fill=NA, no_remove_warning=NULL, overwrite=FALSE, 
   }
   
   #order regions by region name
-  x <- x[sort(getRegions(x)),,]
+  x <- x[robustSort(getRegions(x)),,]
   
   return(updateMetadata(x,calcHistory = "update", cH_priority = 3))  
 }

--- a/R/toolISOhistorical.R
+++ b/R/toolISOhistorical.R
@@ -52,7 +52,7 @@ toolISOhistorical <- function(m,mapping=NULL,additional_mapping=NULL,overwrite=F
   }
     
   # sort mapping(transitions) in historical order -> needed for the correct filling of data
-  mapping <- mapping[order(mapping$lastYear),]
+  mapping <- mapping[robustOrder(mapping$lastYear),]
   # delete transitions from mapping which are not in the time horizon of m
 #  print("The following transitions are ignorred as it exceeds the time horizon of the data",
 #        subset(mapping, mapping$lastYear > max(intersect(mapping$lastYear,getYears(m))))        
@@ -76,7 +76,7 @@ toolISOhistorical <- function(m,mapping=NULL,additional_mapping=NULL,overwrite=F
     }  
     # sort again based on transition year if more than one transition exists
     if (length(ptr[,1]) > 1) {
-       ptr <- ptr[order(ptr[,2]),]
+       ptr <- ptr[robustOrder(ptr[,2]),]
     }
     # calculate number of transitions ntr 
     ntr <- 0

--- a/R/toolOrderCells.R
+++ b/R/toolOrderCells.R
@@ -12,7 +12,7 @@
 toolOrderCells <- function(x){
   if(!is.magpie(x)) stop("Input is not a MAgPIE object, x has to be a MAgPIE object!")
   if(length(getItems(x, split=TRUE)[[1]])!=2 | any(!grepl("[0-9]", getCells(x)))) return(x)
-  out <- x[order(as.integer(getItems(x, dim=1.2))),,]
+  out <- x[robustOrder(as.integer(getItems(x, dim=1.2))),,]
   getComment(out) <- c(getComment(x), paste0("Data reordered by spatial unit number (toolOrderCells): ",date()))
   return(out)
 }

--- a/R/toolXlargest.R
+++ b/R/toolXlargest.R
@@ -18,6 +18,6 @@ toolXlargest <- function(x, range=1:20, years=NULL , elements=NULL, ...) {
   if (!is.null(years)) x <- x[, years, ]
   if (!is.null(elements)) x <- x[,,elements]
   tmp <- dimSums(x, dim = c(2,3))
-  out <- getRegions(tmp[order(tmp, decreasing = TRUE),,])[range]
+  out <- getRegions(tmp[robustOrder(tmp, decreasing = TRUE),,])[range]
   return(out)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **1.102.6**
+R package **madrat**, version **1.102.7**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490)  [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/madrat)
 
@@ -50,7 +50,7 @@ To cite package **madrat** in publications use:
 
 Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2021).
 _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL:
-https://doi.org/10.5281/zenodo.1115490), R package version 1.102.6, <URL: https://github.com/pik-piam/madrat>.
+https://doi.org/10.5281/zenodo.1115490), R package version 1.102.7, <URL: https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -59,7 +59,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2021},
-  note = {R package version 1.102.6},
+  note = {R package version 1.102.7},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **1.102.7**
+R package **madrat**, version **1.102.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490)  [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/madrat)
 
@@ -48,9 +48,10 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2021).
-_madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL:
-https://doi.org/10.5281/zenodo.1115490), R package version 1.102.7, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich
+P (2021). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL:
+https://doi.org/10.5281/zenodo.1115490), R package version 1.102.8, <URL:
+https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -59,7 +60,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2021},
-  note = {R package version 1.102.7},
+  note = {R package version 1.102.8},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/tests/testthat/test-caching.R
+++ b/tests/testthat/test-caching.R
@@ -7,9 +7,10 @@ globalassign <- function(...) {
 test_that("Caching works", {
   calcCacheExample <- function() return(list(x = as.magpie(1), description = "-", unit = "-"))
   globalassign("calcCacheExample")
-  setConfig(globalenv = TRUE, ignorecache = FALSE, cachefolder = paste0(tempdir(),"/bla-blub"), .verbose = FALSE)
+  setConfig(globalenv = TRUE, ignorecache = FALSE, .verbose = FALSE,
+            cachefolder = paste0(tempdir(), "/test_caching_works"))
   expect_null(madrat:::cacheGet("calc","CacheExample"))
-  expect_message(a <- calcOutput("CacheExample", aggregate=FALSE), "writing cache")
+  expect_message(calcOutput("CacheExample", aggregate = FALSE), "writing cache")
   expect_identical(madrat:::cacheGet("calc","CacheExample")$x, as.magpie(1))
   setConfig(ignorecache = TRUE, .verbose = FALSE)
   expect_null(madrat:::cacheGet("calc","CacheExample"))

--- a/tests/testthat/test-robustOrder.R
+++ b/tests/testthat/test-robustOrder.R
@@ -1,0 +1,24 @@
+test_that("robustOrder sorts locale independent", {
+  lcCollate <- Sys.getlocale("LC_COLLATE")
+
+  x <- c("a", "b", "C")
+  Sys.setlocale("LC_COLLATE", "C")
+  expect_equal(order(x), c(3, 1, 2))
+  expect_equal(madrat:::robustOrder(x), c(3, 1, 2))
+
+  Sys.setlocale("LC_COLLATE", "en_US.UTF-8")
+  expect_equal(order(x), c(1, 2, 3))
+  expect_equal(madrat:::robustOrder(x), c(3, 1, 2))
+
+  Sys.setlocale("LC_COLLATE", lcCollate)
+})
+
+test_that("robustOrder can deal with non-UTF-8 strings", {
+  x <- c("2Mor\xe9e et al_2013.pdf", "1Mor\xe9e et al_2013.pdf")
+  expect_error(order(x, method = "radix"), "Character encoding must be UTF-8, Latin-1 or bytes")
+  expect_equal(madrat:::robustOrder(x), c(2, 1))
+  expect_equal(madrat:::robustSort(x), c("1Mor\xe9e et al_2013.pdf", "2Mor\xe9e et al_2013.pdf"))
+
+  x <- c(5, 3, 2, 4)
+  expect_equal(madrat:::robustSort(x, decreasing = TRUE), 5:2)
+})

--- a/tests/testthat/test-robustOrder.R
+++ b/tests/testthat/test-robustOrder.R
@@ -19,6 +19,8 @@ test_that("robustOrder can deal with non-UTF-8 strings", {
   expect_equal(madrat:::robustOrder(x), c(2, 1))
   expect_equal(madrat:::robustSort(x), c("1Mor\xe9e et al_2013.pdf", "2Mor\xe9e et al_2013.pdf"))
 
-  x <- c(5, 3, 2, 4)
-  expect_equal(madrat:::robustSort(x, decreasing = TRUE), 5:2)
+  expect_equal(madrat:::robustSort(c(5, 3, 2, 4), decreasing = TRUE), 5:2)
+  expect_equal(madrat:::robustOrder(c(5, 2, 2, 4), c(0, 1, 0, 17)), c(3, 2, 4, 1))
+  expect_equal(madrat:::robustSort(vector(mode = "character", length = 0)), vector(mode = "character", length = 0))
+  expect_equal(madrat:::robustOrder(vector(mode = "character", length = 0)), vector(mode = "integer", length = 0))
 })

--- a/tests/testthat/test-toolOrderCells.R
+++ b/tests/testthat/test-toolOrderCells.R
@@ -10,6 +10,6 @@ test_that("Equivalence of data", {
 test_that("Ordering works properly for trivial case", {
   getCells(p) <- paste(getItems(p, dim=1),sample(c(1:length(getItems(p, dim=1)))), sep=".") 
   expect_equal(as.numeric(substring(getCells(toolOrderCells(p)),5)), 
-               sort(as.numeric(substring(getCells(p),5))))
+               robustSort(as.numeric(substring(getCells(p),5))))
   expect_error(toolOrderCells(1), "Input is not a MAgPIE object")
 })


### PR DESCRIPTION
Non-utf8 strings no longer lead to crashes (fixes #59) and sorting is now locale independent everywhere.
Added the internal robustOrder and robustSort functions, which are wrapper functions reound base::order and base::sort, but they convert character vectors to utf8 and always use local independent radix sort. In madrat these functions should be used instead of base::order and base::sort.