### PR TITLE
wait for running download in readSource

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5157936'
+ValidationKey: '5158208'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5138431'
+ValidationKey: '5157936'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "<p>Provides a framework which should improve reproducibility and transparency in data processing. It provides functionality such as automatic meta data creation and management, rudimentary quality management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this package to deliver everything what is needed to achieve full reproducibility and transparency, but we believe that it supports efforts in this direction.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
 Version: 2.7.2
-Date: 2021-12-02
+Date: 2021-12-03
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
              person("Stephen", "Wirth", email = "wirth@pik-potsdam.de", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 2.7.1
-Date: 2021-11-30
+Version: 2.7.2
+Date: 2021-12-02
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
              person("Stephen", "Wirth", email = "wirth@pik-potsdam.de", role = "aut"),

--- a/R/downloadSource.R
+++ b/R/downloadSource.R
@@ -8,6 +8,9 @@
 #' @param subtype For some sources there are subtypes of the source, for these source the subtype can be specified
 #' with this argument. If a source does not have subtypes, subtypes should not be set.
 #' @param overwrite Boolean deciding whether existing data should be overwritten or not.
+#' @param numberOfTries Integer determining how often readSource will check whether a running download is finished
+#' before exiting with an error. Between checks readSource will wait 30 seconds. Has no effect if the sources that
+#' should be read are not currently being downloaded.
 #' @note The underlying download-functions are required to provide a list of information
 #' back to \code{downloadSource}. Following list entries should be provided:
 #' \itemize{
@@ -41,12 +44,13 @@
 #' @importFrom yaml write_yaml
 #' @importFrom withr local_dir defer with_dir
 #' @export
-downloadSource <- function(type, subtype = NULL, overwrite = FALSE) {
+downloadSource <- function(type, subtype = NULL, overwrite = FALSE, numberOfTries = 300) {
   argumentValues <- as.list(environment())  # capture arguments for logging
   startinfo <- toolstartmessage("downloadSource", argumentValues, "+")
   defer({
     toolendmessage(startinfo, "-")
   })
+  stopifnot(as.integer(numberOfTries) == numberOfTries, length(numberOfTries) == 1, numberOfTries >= 1)
 
   # check type input
   if (!all(is.character(type)) || length(type) != 1) {
@@ -67,18 +71,39 @@ downloadSource <- function(type, subtype = NULL, overwrite = FALSE) {
   }
 
   typesubtype <- paste(c(make.names(type), make.names(subtype)), collapse = "/")
+  downloadInProgressDirectory <- paste0(typesubtype, "-downloadInProgress")
 
   local_dir(getConfig("sourcefolder"))
-  if (file.exists(typesubtype)) {
+  if (dir.exists(typesubtype)) {
+    if (dir.exists(downloadInProgressDirectory)) {
+      warning("The source folders ", typesubtype, " and ", downloadInProgressDirectory, " should not exist at the ",
+              "same time. Please delete ", normalizePath(downloadInProgressDirectory, winslash = "/"))
+    }
     if (overwrite) {
       unlink(typesubtype, recursive = TRUE)
     } else {
-      stop('Source folder for source "', typesubtype,
-           '" does already exist! Delete folder or activate overwrite to proceed!')
+      stop('Source folder for source "', typesubtype, '" does already exist. Delete that folder or ',
+           "call downloadSource(..., overwrite = TRUE) if you want to re-download.")
+    }
+  } else if (dir.exists(downloadInProgressDirectory)) { # the download is already running in another R session
+    for (i in seq_len(numberOfTries - 1)) { # -1 because one try was already done before
+      argsString <- paste(list(list(type = type, subtype = subtype))) # use paste + list for nicer string output
+      argsString <- substr(argsString, 6, nchar(argsString) - 1) # remove superfluous list from string
+      cat("downloadSource(", argsString, ") is already in progress, waiting 30 seconds...")
+      Sys.sleep(30)
+      if (dir.exists(typesubtype)) {
+        # the parallel running download finished, nothing to do here
+        return()
+      }
+    }
+    if (dir.exists(downloadInProgressDirectory)) {
+      stop("The download did not finish in time. If the download is no longer running delete ",
+           normalizePath(downloadInProgressDirectory, winslash = "/"))
+    } else {
+      warning("Download was not finished, but is no longer running. Starting new download.")
     }
   }
 
-  downloadInProgressDirectory <- paste0(typesubtype, "-downloadInProgress")
   dir.create(downloadInProgressDirectory, recursive = TRUE)
   absolutePath <- normalizePath(downloadInProgressDirectory)
   defer({

--- a/R/readSource.R
+++ b/R/readSource.R
@@ -18,7 +18,7 @@
 #' @return magpie object with the temporal and data dimensionality of the
 #' source data. Spatial will either agree with the source data or will be on
 #' ISO code country level depending on your choice for the argument "convert".
-#' @author Jan Philipp Dietrich, Anastasis Giannousakis, Lavinia Baumstark
+#' @author Jan Philipp Dietrich, Anastasis Giannousakis, Lavinia Baumstark, Pascal Führlich
 #' @seealso \code{\link{setConfig}}, ' \code{\link{downloadSource}},
 #' \code{\link{readTau}}
 #' @examples
@@ -127,8 +127,8 @@ readSource <- function(type, subtype = NULL, convert = TRUE, numberOfTries = 300
 
   # Check whether source folder exists and try do download source data if it is missing
   sourcefolder <- file.path(getConfig("sourcefolder"), make.names(type))
-  if (dir.exists(sourcefolder) && dir.exists(paste0(sourcefolder, "-download_in_progress"))) {
-    warning("The folders ", sourcefolder, " and ", sourcefolder, "-download_in_progress",
+  if (dir.exists(sourcefolder) && dir.exists(paste0(sourcefolder, "-downloadInProgress"))) {
+    warning("The folders ", sourcefolder, " and ", sourcefolder, "-downloadInProgress",
             " should not exist at the same time.")
   }
   # if any DOWNLOAD.yml exists use these files as reference,
@@ -145,7 +145,7 @@ readSource <- function(type, subtype = NULL, convert = TRUE, numberOfTries = 300
   }
 
   if (!.sourceAvailable(sourcefolder, type, subtype)) {
-    if (dir.exists(paste0(sourcefolder, "-download_in_progress"))) { # the download is already running
+    if (dir.exists(paste0(sourcefolder, "-downloadInProgress"))) { # the download is already running
       for (i in seq_len(numberOfTries - 1)) { # -1 because one try was already done before
         Sys.sleep(30) # wait 30 seconds
         if (.sourceAvailable(sourcefolder, type, subtype)) {

--- a/R/readSource.R
+++ b/R/readSource.R
@@ -140,20 +140,23 @@ readSource <- function(type, subtype = NULL, convert = TRUE, numberOfTries = 300
     } else {
       sourcefile <- file.path(getConfig("sourcefolder"), make.names(type), "DOWNLOAD.yml")
       sourcesubfile <- file.path(getConfig("sourcefolder"), make.names(type), make.names(subtype), "DOWNLOAD.yml")
-      return(file.exists(sourcefile) || file.exists(sourcesubfile))
+      return(isTRUE(file.exists(sourcefile)) || isTRUE(file.exists(sourcesubfile)))
     }
   }
 
   if (!.sourceAvailable(sourcefolder, type, subtype)) {
     if (dir.exists(paste0(sourcefolder, "-downloadInProgress"))) { # the download is already running
       for (i in seq_len(numberOfTries - 1)) { # -1 because one try was already done before
-        Sys.sleep(30) # wait 30 seconds
+        argsString <- paste(list(list(type = type, subtype = subtype))) # use paste + list for nicer string output
+        argsString <- substr(argsString, 6, nchar(argsString) - 1) # remove superfluous list from string
+        cat("downloadSource(", argsString, ") is already in progress, waiting 30 seconds...")
+        Sys.sleep(30)
         if (.sourceAvailable(sourcefolder, type, subtype)) {
           break
         }
       }
       if (!.sourceAvailable(sourcefolder, type, subtype)) {
-        stop("The download of ", type, " did not finish in time.")
+        stop("The download did not finish in time.")
       }
     } else if (type %in% getSources(type = "download")) { # does a routine exist to download the source data?
       downloadSource(type = type, subtype = subtype)

--- a/R/readSource.R
+++ b/R/readSource.R
@@ -37,12 +37,14 @@ readSource <- function(type, subtype = NULL, convert = TRUE) { # nolint
   })
 
   # check type input
-  if (!is.character(type) || length(type) != 1) stop("Invalid type (must be a single character string)!")
+  if (!is.character(type) || length(type) != 1) {
+    stop("Invalid type (must be a single character string)!")
+  }
 
   # Does the source that should be read exist?
   if (!(type %in% getSources(type = "read"))) {
     stop('Type "', type, '" is not a valid source type. Available sources are: "',
-      paste(getSources(type = "read"), collapse = '", "'), '"')
+         paste(getSources(type = "read"), collapse = '", "'), '"')
   }
 
   # Does a correctTYPE function exist?
@@ -57,21 +59,26 @@ readSource <- function(type, subtype = NULL, convert = TRUE) { # nolint
     names(isoCountry1) <- isoCountry[, "X"]
     isocountries  <- robustSort(isoCountry1)
     datacountries <- robustSort(x)
-    if (length(isocountries) != length(datacountries)) stop("Wrong number of countries returned by ", functionname, "!")
-    if (any(isocountries != datacountries)) stop("Countries returned by ", functionname,
-      " do not agree with iso country list!")
+    if (length(isocountries) != length(datacountries)) {
+      stop("Wrong number of countries returned by ", functionname, "!")
+    }
+    if (any(isocountries != datacountries)) {
+      stop("Countries returned by ", functionname, " do not agree with iso country list!")
+    }
   }
 
   .getData <- function(type, subtype, prefix = "read") {
     # get data either from cache or by calculating it from source
-    sourcefolder <- paste0(getConfig("sourcefolder"), "/", make.names(type))
-    if (!is.null(subtype) && file.exists(paste0(sourcefolder, "/", make.names(subtype), "/DOWNLOAD.yml"))) {
-      sourcefolder <- paste0(sourcefolder, "/", make.names(subtype))
+    sourcefolder <- file.path(getConfig("sourcefolder"), make.names(type))
+    if (!is.null(subtype) && file.exists(file.path(sourcefolder, make.names(subtype), "DOWNLOAD.yml"))) {
+      sourcefolder <- file.path(sourcefolder, make.names(subtype))
     }
 
     fname <- paste0(prefix, type, subtype)
     args <- NULL
-    if (!is.null(subtype)) args <- list(subtype = subtype)
+    if (!is.null(subtype)) {
+      args <- list(subtype = subtype)
+    }
     x <- cacheGet(prefix = prefix, type = type, args = args)
     if (!is.null(x) && prefix == "convert") {
       err <- try(testISO(getItems(x, dim = 1.1), functionname = fname), silent = TRUE)
@@ -98,26 +105,30 @@ readSource <- function(type, subtype = NULL, convert = TRUE) { # nolint
       functionname <- prepFunctionName(type = type, prefix = prefix, ignore = ifelse(is.null(subtype), "subtype", NA))
       x <- eval(parse(text = functionname))
     })
-    if (!is.magpie(x)) stop("Output of function \"", functionname, "\" is not a MAgPIE object!")
+    if (!is.magpie(x)) {
+      stop('Output of function "', functionname, '" is not a MAgPIE object!')
+    }
     if (prefix == "convert") {
       testISO(getItems(x, dim = 1.1), functionname = functionname)
     }
     args <- NULL
-    if (!is.null(subtype)) args <- list(subtype = subtype)
+    if (!is.null(subtype)) {
+      args <- list(subtype = subtype)
+    }
     cachePut(x, prefix = prefix, type = type, args = args)
     return(x)
   }
 
   # Check whether source folder exists and try do download source data if it is missing
-  sourcefolder <- paste0(getConfig("sourcefolder"), "/", type)
+  sourcefolder <- file.path(getConfig("sourcefolder"), type)
   # if any DOWNLOAD.yml exists use these files as reference,
   # otherwise just check whether the sourcefolder exists
   df <- dir(sourcefolder, recursive = TRUE, pattern = "DOWNLOAD.yml")
   if (length(df) == 0) {
     sourceMissing <- !file.exists(sourcefolder)
   } else {
-    sourcefile <- paste0(getConfig("sourcefolder"), "/", make.names(type), "/DOWNLOAD.yml")
-    sourcesubfile <- paste0(getConfig("sourcefolder"), "/", make.names(type), "/", make.names(subtype), "/DOWNLOAD.yml")
+    sourcefile <- file.path(getConfig("sourcefolder"), make.names(type), "DOWNLOAD.yml")
+    sourcesubfile <- file.path(getConfig("sourcefolder"), make.names(type), make.names(subtype), "DOWNLOAD.yml")
     sourceMissing <- (!file.exists(sourcefile) && !file.exists(sourcesubfile))
   }
 
@@ -126,14 +137,15 @@ readSource <- function(type, subtype = NULL, convert = TRUE) { # nolint
     if (type %in% getSources(type = "download")) {
       downloadSource(type = type, subtype = subtype)
     } else {
-      typesubtype <- paste0(paste(c(paste0("type = \"", type), subtype), collapse = "\" subtype = \""), "\"")
+      typesubtype <- paste0(paste(c(paste0('type = "', type), subtype), collapse = '" subtype = "'), '"')
       stop("Sourcefolder does not contain data for the requested source ", typesubtype,
-        " and there is no download script which could provide the missing data. Please check your settings!")
+           " and there is no download script which could provide the missing data. Please check your settings!")
     }
   }
 
-  if (!is.logical(convert) && convert != "onlycorrect") stop("Unknown convert setting \"", convert,
-    "\" (allowed: TRUE, FALSE and \"onlycorrect\") ")
+  if (!is.logical(convert) && convert != "onlycorrect") {
+    stop('Unknown convert setting "', convert, '" (allowed: TRUE, FALSE and "onlycorrect")')
+  }
 
   if (convert == TRUE && (type %in% getSources(type = "convert"))) {
     prefix <- "convert"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **2.7.1**
+R package **madrat**, version **2.7.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2021). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 2.7.1, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2021). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 2.7.2, <URL: https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2021},
-  note = {R package version 2.7.1},
+  note = {R package version 2.7.2},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/man/downloadSource.Rd
+++ b/man/downloadSource.Rd
@@ -4,7 +4,7 @@
 \alias{downloadSource}
 \title{downloadSource}
 \usage{
-downloadSource(type, subtype = NULL, overwrite = FALSE)
+downloadSource(type, subtype = NULL, overwrite = FALSE, numberOfTries = 300)
 }
 \arguments{
 \item{type}{source type, e.g. "IEA". A list of all available source types can be retrieved with
@@ -14,6 +14,10 @@ function \code{\link{getSources}("download")}.}
 with this argument. If a source does not have subtypes, subtypes should not be set.}
 
 \item{overwrite}{Boolean deciding whether existing data should be overwritten or not.}
+
+\item{numberOfTries}{Integer determining how often readSource will check whether a running download is finished
+before exiting with an error. Between checks readSource will wait 30 seconds. Has no effect if the sources that
+should be read are not currently being downloaded.}
 }
 \description{
 Download a source. The function is a wrapper for specific functions designed

--- a/man/downloadSource.Rd
+++ b/man/downloadSource.Rd
@@ -7,23 +7,21 @@
 downloadSource(type, subtype = NULL, overwrite = FALSE)
 }
 \arguments{
-\item{type}{source type, e.g. "IEA". A list of all available source types
-can be retrieved with function \code{\link{getSources}("download")}.}
+\item{type}{source type, e.g. "IEA". A list of all available source types can be retrieved with
+function \code{\link{getSources}("download")}.}
 
-\item{subtype}{For some sources there are subtypes of the source, for these
-source the subtype can be specified with this argument. If a source does not
-have subtypes, subtypes should not be set.}
+\item{subtype}{For some sources there are subtypes of the source, for these source the subtype can be specified
+with this argument. If a source does not have subtypes, subtypes should not be set.}
 
-\item{overwrite}{Boolean deciding whether existing data should be
-overwritten or not.}
+\item{overwrite}{Boolean deciding whether existing data should be overwritten or not.}
 }
 \description{
 Download a source. The function is a wrapper for specific functions designed
 for the different possible source types.
 }
 \note{
-The underlying download-functions are required to provide a list of information back to
-\code{downloadSource}. Following list entries should be provided:
+The underlying download-functions are required to provide a list of information
+back to \code{downloadSource}. Following list entries should be provided:
 \itemize{
 \item \bold{url} - full path to the file that should be downloaded
 \item \bold{title} - title of the data source
@@ -51,11 +49,10 @@ extending the return list with additional, named entries.
 \dontrun{
 a <- downloadSource("Tau", subtype = "historical")
 }
-
 }
 \seealso{
 \code{\link{setConfig}}, \code{\link{readSource}}
 }
 \author{
-Jan Philipp Dietrich, David Klein
+Jan Philipp Dietrich, David Klein, Pascal Führlich
 }

--- a/man/readSource.Rd
+++ b/man/readSource.Rd
@@ -43,5 +43,5 @@ a <- readSource("Tau", "paper")
 \code{\link{readTau}}
 }
 \author{
-Jan Philipp Dietrich, Anastasis Giannousakis, Lavinia Baumstark
+Jan Philipp Dietrich, Anastasis Giannousakis, Lavinia Baumstark, Pascal Führlich
 }

--- a/man/readSource.Rd
+++ b/man/readSource.Rd
@@ -4,7 +4,7 @@
 \alias{readSource}
 \title{readSource}
 \usage{
-readSource(type, subtype = NULL, convert = TRUE)
+readSource(type, subtype = NULL, convert = TRUE, numberOfTries = 300)
 }
 \arguments{
 \item{type}{source type, e.g. "IEA". A list of all available source types
@@ -17,6 +17,10 @@ have subtypes, subtypes should not be set.}
 \item{convert}{Boolean indicating whether input data conversion to
 ISO countries should be done or not. In addition it can be set to "onlycorrect"
 for sources with a separate correctXXX-function.}
+
+\item{numberOfTries}{Integer determining how often readSource will check whether a running download is finished
+before exiting with an error. Between checks readSource will wait 30 seconds. Has no effect if the sources that
+should be read are not currently being downloaded.}
 }
 \value{
 magpie object with the temporal and data dimensionality of the

--- a/man/readSource.Rd
+++ b/man/readSource.Rd
@@ -4,7 +4,7 @@
 \alias{readSource}
 \title{readSource}
 \usage{
-readSource(type, subtype = NULL, convert = TRUE, numberOfTries = 300)
+readSource(type, subtype = NULL, convert = TRUE)
 }
 \arguments{
 \item{type}{source type, e.g. "IEA". A list of all available source types
@@ -17,10 +17,6 @@ have subtypes, subtypes should not be set.}
 \item{convert}{Boolean indicating whether input data conversion to
 ISO countries should be done or not. In addition it can be set to "onlycorrect"
 for sources with a separate correctXXX-function.}
-
-\item{numberOfTries}{Integer determining how often readSource will check whether a running download is finished
-before exiting with an error. Between checks readSource will wait 30 seconds. Has no effect if the sources that
-should be read are not currently being downloaded.}
 }
 \value{
 magpie object with the temporal and data dimensionality of the
@@ -43,5 +39,5 @@ a <- readSource("Tau", "paper")
 \code{\link{readTau}}
 }
 \author{
-Jan Philipp Dietrich, Anastasis Giannousakis, Lavinia Baumstark, Pascal Führlich
+Jan Philipp Dietrich, Anastasis Giannousakis, Lavinia Baumstark
 }

--- a/tests/testthat/test-downloadSource.R
+++ b/tests/testthat/test-downloadSource.R
@@ -18,3 +18,24 @@ test_that("downloadSource uses temporary downloadInProgress directory", {
   downloadSource("Test")
   expect_true(dir.exists(file.path(mainfolder, "sources", "Test")))
 })
+
+test_that("downloadSource waits until already running download is finished", {
+  mainfolder <- normalizePath(withr::local_tempdir(), winslash = "/")
+  setConfig(mainfolder = mainfolder, .local = TRUE)
+  dir.create(file.path(mainfolder, "sources", "Tau-downloadInProgress"), recursive = TRUE)
+
+  expect_error(downloadSource("Tau", numberOfTries = 1),
+               paste("The download did not finish in time. If the download is no longer running delete",
+                     file.path(mainfolder, "sources", "Tau-downloadInProgress")), fixed = TRUE)
+  dir.create(file.path(mainfolder, "sources", "Tau"), recursive = TRUE)
+  expect_error(downloadSource("Tau", numberOfTries = 1.45),
+               "as.integer(numberOfTries) == numberOfTries is not TRUE", fixed = TRUE)
+  expect_error(downloadSource("Tau", numberOfTries = 1:3), "length(numberOfTries) == 1 is not TRUE", fixed = TRUE)
+  expect_error(downloadSource("Tau", numberOfTries = -1), "numberOfTries >= 1 is not TRUE", fixed = TRUE)
+  withr::with_options(list(warn = 2), {# turn warnings into error so execution is stopped after warning
+    expect_error(downloadSource("Tau", numberOfTries = 1),
+                 paste("The source folders Tau and Tau-downloadInProgress should not exist at the same time.",
+                       "Please delete", file.path(mainfolder, "sources", "Tau-downloadInProgress")),
+                 fixed = TRUE)
+  })
+})

--- a/tests/testthat/test-downloadSource.R
+++ b/tests/testthat/test-downloadSource.R
@@ -1,0 +1,20 @@
+globalassign <- function(...) {
+  for (x in c(...)) assign(x, eval.parent(parse(text = x)), .GlobalEnv)
+}
+
+test_that("downloadSource uses temporary downloadInProgress directory", {
+  mainfolder <- normalizePath(withr::local_tempdir(), winslash = "/")
+  setConfig(mainfolder = mainfolder, globalenv = TRUE, .local = TRUE)
+
+  downloadTest <- function() {
+    expect_false(dir.exists(file.path(mainfolder, "sources", "Test")))
+    expect_true(dir.exists(file.path(mainfolder, "sources", "Test-downloadInProgress")))
+    return(list(url = "dummy", author = "dummy", title = "dummy", license = "dummy",
+                description = "dummy", unit = "dummy"))
+  }
+  globalassign("downloadTest")
+
+  expect_false(dir.exists(file.path(mainfolder, "sources", "Test")))
+  downloadSource("Test")
+  expect_true(dir.exists(file.path(mainfolder, "sources", "Test")))
+})

--- a/tests/testthat/test-readSource.R
+++ b/tests/testthat/test-readSource.R
@@ -11,25 +11,6 @@ nce <- function(x) {
   return(x)
 }
 
-test_that("readSource waits until download is finished", {
-  mainfolder <- normalizePath(withr::local_tempdir(), winslash = "/")
-  setConfig(mainfolder = mainfolder, .local = TRUE)
-  dir.create(file.path(mainfolder, "sources", "Tau-downloadInProgress"), recursive = TRUE)
-  expect_error(readSource("Tau", numberOfTries = 1), "The download did not finish in time.", fixed = TRUE)
-  dir.create(file.path(mainfolder, "sources", "Tau"), recursive = TRUE)
-  expect_error(readSource("Tau", numberOfTries = 1.45),
-               "as.integer(numberOfTries) == numberOfTries is not TRUE", fixed = TRUE)
-  expect_error(readSource("Tau", numberOfTries = 1:3), "length(numberOfTries) == 1 is not TRUE", fixed = TRUE)
-  expect_error(readSource("Tau", numberOfTries = -1), "numberOfTries >= 1 is not TRUE", fixed = TRUE)
-  withr::with_options(list(warn = 2), {# turn warning into error so execution is stopped after warning
-    expect_error(readSource("Tau", numberOfTries = 1),
-                 paste0("The folders ", file.path(mainfolder, "sources", "Tau"), " and ",
-                        file.path(mainfolder, "sources", "Tau-downloadInProgress"),
-                        " should not exist at the same time."),
-                 fixed = TRUE)
-  })
-})
-
 test_that("readSource detects common problems", {
   setConfig(globalenv = TRUE, verbosity = 2, .verbose = FALSE, mainfolder = tempdir(), .local = TRUE)
   readNoDownload <- function() {} # nolint
@@ -94,7 +75,9 @@ test_that("downloadSource works", {
   skip_on_cran()
   skip_if_offline("zenodo.org")
   setConfig(globalenv = TRUE, verbosity = 2, .verbose = FALSE, mainfolder = tempdir(), .local = TRUE)
-  expect_error(downloadSource("Tau", "paper"), "does already exist!")
+  expect_error(downloadSource("Tau", "paper"),
+               paste('Source folder for source "Tau/paper" does already exist. Delete that folder or call',
+                     "downloadSource(..., overwrite = TRUE) if you want to re-download."), fixed = TRUE)
   expect_error(downloadSource(1:10), "Invalid type")
   expect_error(downloadSource("Tau", subtype = 1:10), "Invalid subtype")
   downloadTest <- function() return(list(url = 1, author = 1, title = 1, license = 1,

--- a/tests/testthat/test-readSource.R
+++ b/tests/testthat/test-readSource.R
@@ -15,7 +15,7 @@ test_that("readSource waits until download is finished", {
   mainfolder <- normalizePath(withr::local_tempdir(), winslash = "/")
   setConfig(mainfolder = mainfolder, .local = TRUE)
   dir.create(file.path(mainfolder, "sources", "Tau-downloadInProgress"), recursive = TRUE)
-  expect_error(readSource("Tau", numberOfTries = 1), "The download of Tau did not finish in time.", fixed = TRUE)
+  expect_error(readSource("Tau", numberOfTries = 1), "The download did not finish in time.", fixed = TRUE)
   dir.create(file.path(mainfolder, "sources", "Tau"), recursive = TRUE)
   expect_error(readSource("Tau", numberOfTries = 1.45),
                "as.integer(numberOfTries) == numberOfTries is not TRUE", fixed = TRUE)

--- a/tests/testthat/test-readSource.R
+++ b/tests/testthat/test-readSource.R
@@ -11,6 +11,25 @@ nce <- function(x) {
   return(x)
 }
 
+test_that("readSource waits until download is finished", {
+  mainfolder <- normalizePath(withr::local_tempdir(), winslash = "/")
+  setConfig(mainfolder = mainfolder, .local = TRUE)
+  dir.create(file.path(mainfolder, "sources", "Tau-download_in_progress"), recursive = TRUE)
+  expect_error(readSource("Tau", numberOfTries = 1), "The download of Tau did not finish in time.", fixed = TRUE)
+  dir.create(file.path(mainfolder, "sources", "Tau"), recursive = TRUE)
+  expect_error(readSource("Tau", numberOfTries = 1.45),
+               "as.integer(numberOfTries) == numberOfTries is not TRUE", fixed = TRUE)
+  expect_error(readSource("Tau", numberOfTries = 1:3), "length(numberOfTries) == 1 is not TRUE", fixed = TRUE)
+  expect_error(readSource("Tau", numberOfTries = -1), "numberOfTries >= 1 is not TRUE", fixed = TRUE)
+  withr::with_options(list(warn = 2), {# turn warning into error so execution is stopped after warning
+    expect_error(readSource("Tau", numberOfTries = 1),
+                 paste0("The folders ", file.path(mainfolder, "sources", "Tau"), " and ",
+                        file.path(mainfolder, "sources", "Tau-download_in_progress"),
+                        " should not exist at the same time."),
+                 fixed = TRUE)
+  })
+})
+
 test_that("readSource detects common problems", {
   setConfig(globalenv = TRUE, verbosity = 2, .verbose = FALSE, mainfolder = tempdir(), .local = TRUE)
   readNoDownload <- function() {} # nolint

--- a/tests/testthat/test-readSource.R
+++ b/tests/testthat/test-readSource.R
@@ -14,7 +14,7 @@ nce <- function(x) {
 test_that("readSource waits until download is finished", {
   mainfolder <- normalizePath(withr::local_tempdir(), winslash = "/")
   setConfig(mainfolder = mainfolder, .local = TRUE)
-  dir.create(file.path(mainfolder, "sources", "Tau-download_in_progress"), recursive = TRUE)
+  dir.create(file.path(mainfolder, "sources", "Tau-downloadInProgress"), recursive = TRUE)
   expect_error(readSource("Tau", numberOfTries = 1), "The download of Tau did not finish in time.", fixed = TRUE)
   dir.create(file.path(mainfolder, "sources", "Tau"), recursive = TRUE)
   expect_error(readSource("Tau", numberOfTries = 1.45),
@@ -24,7 +24,7 @@ test_that("readSource waits until download is finished", {
   withr::with_options(list(warn = 2), {# turn warning into error so execution is stopped after warning
     expect_error(readSource("Tau", numberOfTries = 1),
                  paste0("The folders ", file.path(mainfolder, "sources", "Tau"), " and ",
-                        file.path(mainfolder, "sources", "Tau-download_in_progress"),
+                        file.path(mainfolder, "sources", "Tau-downloadInProgress"),
                         " should not exist at the same time."),
                  fixed = TRUE)
   })


### PR DESCRIPTION
This PR deals with the following situation: A source is being downloaded (downloadSource) and in another parallel running R session that source is read (readSource). At the moment readSource would try to read the partially downloaded data and probably crash. With this PR readSource will recognize the running download and wait. downloadSource now writes into a folder called `<type>-downloadInProgress` and when the download is finished that folder is renamed to `<type>`.