### PR TITLE
fixed a warning in toolCountryFill

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '40846180'
+ValidationKey: '40867408'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "<p>Provides a framework which should improve reproducibility and transparency in data processing. It provides functionality such as automatic meta data creation and management, rudimentary quality management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this package to deliver everything what is needed to achieve full reproducibility and transparency, but we believe that it supports efforts in this direction.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 2.14.0
-Date: 2022-04-05
+Version: 2.14.1
+Date: 2022-04-06
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
              person("Stephen", "Wirth", email = "wirth@pik-potsdam.de", role = "aut"),

--- a/R/toolCountryFill.R
+++ b/R/toolCountryFill.R
@@ -39,7 +39,7 @@
 #' y <- toolCountryFill(x, 99)
 #' @importFrom magclass getItems new.magpie getYears getNames mbind setCells
 #' @export
-toolCountryFill <- function(x, fill = NA, no_remove_warning = NULL, overwrite = FALSE, verbosity = 1, #nolint
+toolCountryFill <- function(x, fill = NA, no_remove_warning = NULL, overwrite = FALSE, verbosity = 1, # nolint
                             countrylist = NULL, ...) {
   if (is.null(countrylist)) {
     isoCountry <- read.csv2(system.file("extdata", "iso_country.csv", package = "madrat"), row.names = NULL)
@@ -101,7 +101,11 @@ toolCountryFill <- function(x, fill = NA, no_remove_warning = NULL, overwrite = 
     }
 
     tmp <- new.magpie(missingCountries, getYears(x), getNames(x), fill = fill)
-    x <- mbind(x, tmp)
+    if (length(x) == 0) {
+      x <- tmp
+    } else {
+      x <- mbind(x, tmp)
+    }
 
     # map data as defined by additional mappings
     if (!is.null(map)) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **2.14.0**
+R package **madrat**, version **2.14.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2022). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 2.14.0, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2022). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 2.14.1, <URL: https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2022},
-  note = {R package version 2.14.0},
+  note = {R package version 2.14.1},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/tests/testthat/test-toolCountryFill.R
+++ b/tests/testthat/test-toolCountryFill.R
@@ -22,4 +22,10 @@ test_that("toolCountryFill works as expected", {
   expect_true(toolCountryFill(x3, 99, FRA = "DEU")["FRA", , ] == 42)
   expect_message(y5 <- toolCountryFill(x3, 99, FRA = "DEU", overwrite = TRUE), "data overwritten")
   expect_true(y5["FRA", , ] == 0)
+
+  empty <- new.magpie(NULL, NULL, c("bla"))
+  expect_silent(y6 <- toolCountryFill(empty, verbosity = 3))
+  expect_identical(getItems(y6, dim = c(2, 3)), getItems(empty, dim = c(2, 3)))
+  expect_identical(getItems(y6, dim = 1), getItems(y5, dim = 1))
+
 })


### PR DESCRIPTION
fixed a warning in toolCountryFill which was triggered when an empty magclass object was expanded over all iso countries