### PR TITLE
fix vcat 'list cannot be handled by cat'

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42068864'
+ValidationKey: '42125337'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -11,7 +11,7 @@ on:
 env:
   USE_BSPM: "true"
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen")'
+  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc")'
 
 jobs:
   lucode2-check:
@@ -56,6 +56,11 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
       - name: Cache R libraries
         uses: pat-s/always-upload-cache@v3
         with:
@@ -70,9 +75,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ./run.sh install_aptget libhdf5-dev
+          ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
           ./run.sh install_all
           ./run.sh install_r lucode2 covr rstudioapi
+
+      - name: Install python dependencies if applicable
+        run: |
+          [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
+          [ -f requirements.txt ] && pip install -r requirements.txt || true
 
       - name: Remove bspm integration # to get rid of error when running install.packages
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,22 @@ repos:
     hooks:
     -   id: check-case-conflict
     -   id: check-json
-    -   id: check-yaml
     -   id: check-merge-conflict
+    -   id: check-yaml
     -   id: fix-byte-order-marker
+    -   id: check-added-large-files
+        args: ['--maxkb=100']
+    -   id: mixed-line-ending
+
+-   repo: https://github.com/lorenzwalthert/precommit
+    rev: v0.3.2
+    hooks:
+    -   id: parsable-R
+    -   id: deps-in-desc
+        args: [--allow_private_imports]
+    -   id: no-browser-statement
+    -   id: no-debug-statement
+    -   id: readme-rmd-rendered
+    -   id: use-tidy-description
 ci:
     autoupdate_schedule: quarterly

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "2.19.2",
+  "version": "2.19.3",
   "description": "<p>Provides a framework which should improve reproducibility and transparency in data processing. It provides functionality such as automatic meta data creation and management, rudimentary quality management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this package to deliver everything what is needed to achieve full reproducibility and transparency, but we believe that it supports efforts in this direction.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,22 +1,34 @@
-Package: madrat
 Type: Package
+Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 2.19.2
-Date: 2022-07-19
-Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
-             person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
-             person("Stephen", "Wirth", email = "wirth@pik-potsdam.de", role = "aut"),
-             person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = "aut"),
-             person("Renato", "Rodrigues", email = "Renato.Rodrigues@pik-potsdam.de", role = "aut"),
-             person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
-             person("Ulrich", "Kreidenweis", email = "kreidenweis@pik-potsdam.de", role = "aut"),
-             person("David", "Klein", email = "dklein@pik-potsdam.de", role = "aut"),
-             person("Pascal", "Führlich", email = "pascal.fuehrlich@pik-potsdam.de", role = "aut"))
-Description: Provides a framework which should improve reproducibility and transparency in data processing. It provides functionality such as automatic meta data creation and management, rudimentary quality management, data caching, work-flow management and data aggregation.
-    * The title is a wish not a promise. By no means we expect this package to deliver everything what is needed to achieve full reproducibility and transparency, but we believe that it supports efforts in this direction.
+Version: 2.19.3
+Date: 2022-08-05
+Authors@R: c(
+    person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
+    person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = "aut"),
+    person("Stephen", "Wirth", , "wirth@pik-potsdam.de", role = "aut"),
+    person("Anastasis", "Giannousakis", , "giannou@pik-potsdam.de", role = "aut"),
+    person("Renato", "Rodrigues", , "Renato.Rodrigues@pik-potsdam.de", role = "aut"),
+    person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = "aut"),
+    person("Ulrich", "Kreidenweis", , "kreidenweis@pik-potsdam.de", role = "aut"),
+    person("David", "Klein", , "dklein@pik-potsdam.de", role = "aut"),
+    person("Pascal", "Führlich", , "pascal.fuehrlich@pik-potsdam.de", role = "aut")
+  )
+Description: Provides a framework which should improve reproducibility and
+    transparency in data processing. It provides functionality such as
+    automatic meta data creation and management, rudimentary quality
+    management, data caching, work-flow management and data aggregation.
+    * The title is a wish not a promise. By no means we expect this
+    package to deliver everything what is needed to achieve full
+    reproducibility and transparency, but we believe that it supports
+    efforts in this direction.
+License: BSD_2_clause + file LICENSE
+URL: https://github.com/pik-piam/madrat,
+    https://doi.org/10.5281/zenodo.1115490
+BugReports: https://github.com/pik-piam/madrat/issues
 Depends:
-    magclass(>= 5.7.0),
-    R(>= 2.10.0)
+    magclass (>= 5.7.0),
+    R (>= 2.10.0)
 Imports:
     callr,
     digest,
@@ -37,10 +49,8 @@ Suggests:
     rmarkdown,
     testthat,
     tibble
-URL: https://github.com/pik-piam/madrat, https://doi.org/10.5281/zenodo.1115490
-BugReports: https://github.com/pik-piam/madrat/issues
-License: BSD_2_clause + file LICENSE
-VignetteBuilder: knitr
+VignetteBuilder:
+    knitr
 Encoding: UTF-8
 LazyData: no
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/R/vcat.R
+++ b/R/vcat.R
@@ -34,6 +34,9 @@
 #' @importFrom utils capture.output
 vcat <- function(verbosity, ..., level = NULL, fill = TRUE,
                  show_prefix = TRUE, logOnly = FALSE) { # nolint
+  # deparse lists to character to prevent `(type 'list') cannot be handled by 'cat'`
+  messages <- lapply(list(...), function(x) if (is.list(x)) deparse(x) else x)
+  messages <- as.character(messages)
 
   # make sure that vcat is not run from within another vcat
   if (isWrapperActive("vcat")) return()
@@ -59,25 +62,25 @@ vcat <- function(verbosity, ..., level = NULL, fill = TRUE,
     writelog <- FALSE
   }
   prefix <- c("", "ERROR: ", "WARNING: ", "NOTE: ", "MINOR NOTE: ")[min(verbosity, 2) + 3]
-  if (prefix == "" | !show_prefix) prefix <- NULL
+  if (prefix == "" || !show_prefix) prefix <- NULL
   if (writelog && dir.exists(dirname(fulllogfile))) {
-    base::cat(c(prefix, ...), fill = fill, sep = "", labels = getOption("gdt_nestinglevel"),
+    base::cat(c(prefix, messages), fill = fill, sep = "", labels = getOption("gdt_nestinglevel"),
               file = fulllogfile, append = TRUE)
   }
   if (getConfig("verbosity") >= verbosity) {
     if (writelog && dir.exists(dirname(logfile))) {
-      base::cat(c(prefix, ...), fill = fill, sep = "", labels = getOption("gdt_nestinglevel"),
+      base::cat(c(prefix, messages), fill = fill, sep = "", labels = getOption("gdt_nestinglevel"),
                 file = logfile, append = TRUE)
     }
     if (verbosity == -1) {
-      base::message(paste(capture.output(base::cat(c(prefix, ...),
+      base::message(paste(capture.output(base::cat(c(prefix, messages),
                                                    fill = fill, sep = "",
                                                    labels = getOption("gdt_nestinglevel")
       )), collapse = "\n"))
       if (!logOnly) base::stop(..., call. = FALSE)
     } else if (verbosity == 0) {
       if (!logOnly) base::warning(..., call. = FALSE)
-      base::message(paste(capture.output(base::cat(c(prefix, ...),
+      base::message(paste(capture.output(base::cat(c(prefix, messages),
         fill = fill, sep = "",
         labels = getOption("gdt_nestinglevel")
       )), collapse = "\n"))
@@ -85,7 +88,7 @@ vcat <- function(verbosity, ..., level = NULL, fill = TRUE,
         options(madratWarningsCounter = getOption("madratWarningsCounter") + 1) # nolint
       }
     } else {
-      base::message(paste(capture.output(base::cat(c(prefix, ...),
+      base::message(paste(capture.output(base::cat(c(prefix, messages),
         fill = fill, sep = "",
         labels = getOption("gdt_nestinglevel")
       )), collapse = "\n"))

--- a/R/vcat.R
+++ b/R/vcat.R
@@ -54,12 +54,10 @@ vcat <- function(verbosity, ..., level = NULL, fill = TRUE,
   }
 
   d <- getConfig("diagnostics")
-  if (is.character(d)) {
-    writelog <- TRUE
+  writelog <- is.character(d)
+  if (writelog) {
     logfile <- paste0(getConfig("outputfolder"), "/", d, ".log")
     fulllogfile <- paste0(getConfig("outputfolder"), "/", d, "_full.log")
-  } else {
-    writelog <- FALSE
   }
   prefix <- c("", "ERROR: ", "WARNING: ", "NOTE: ", "MINOR NOTE: ")[min(verbosity, 2) + 3]
   if (prefix == "" || !show_prefix) prefix <- NULL
@@ -77,28 +75,24 @@ vcat <- function(verbosity, ..., level = NULL, fill = TRUE,
                                                    fill = fill, sep = "",
                                                    labels = getOption("gdt_nestinglevel")
       )), collapse = "\n"))
-      if (!logOnly) base::stop(..., call. = FALSE)
-    } else if (verbosity == 0) {
-      if (!logOnly) base::warning(..., call. = FALSE)
-      base::message(paste(capture.output(base::cat(c(prefix, messages),
-        fill = fill, sep = "",
-        labels = getOption("gdt_nestinglevel")
-      )), collapse = "\n"))
-      if (!is.null(getOption("madratWarningsCounter"))) {
-        options(madratWarningsCounter = getOption("madratWarningsCounter") + 1) # nolint
+      if (!logOnly) {
+        base::stop(..., call. = FALSE)
       }
+    } else if (verbosity == 0) {
+      if (!logOnly) {
+        base::warning(..., call. = FALSE)
+      }
+      base::message(paste(capture.output(base::cat(c(prefix, messages), fill = fill, sep = "",
+                                                   labels = getOption("gdt_nestinglevel"))), collapse = "\n"))
+      options(madratWarningsCounter = getOption("madratWarningsCounter", 0) + 1) # nolint
     } else {
-      base::message(paste(capture.output(base::cat(c(prefix, messages),
-        fill = fill, sep = "",
-        labels = getOption("gdt_nestinglevel")
-      )), collapse = "\n"))
+      base::message(paste(capture.output(base::cat(c(prefix, messages), fill = fill, sep = "",
+                                                   labels = getOption("gdt_nestinglevel"))), collapse = "\n"))
     }
   }
 
-  if (!is.null(level)) {
-    if (level == "+") {
-      options(gdt_nestinglevel = paste0("~", getOption("gdt_nestinglevel"))) # nolint
-    }
+  if (identical(level, "+")) {
+    options(gdt_nestinglevel = paste0("~", getOption("gdt_nestinglevel"))) # nolint
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **2.19.2**
+R package **madrat**, version **2.19.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2022). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 2.19.2, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2022). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 2.19.3, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2022},
-  note = {R package version 2.19.2},
+  note = {R package version 2.19.3},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/man/isWrapperActive.Rd
+++ b/man/isWrapperActive.Rd
@@ -22,11 +22,11 @@ automatically resetted when a function finishes).
 }
 \section{Functions}{
 \itemize{
-\item \code{setWrapperActive}: set wrapper activity status to on
+\item \code{setWrapperActive()}: set wrapper activity status to on
 
-\item \code{setWrapperInactive}: set wrapper activity status to off
+\item \code{setWrapperInactive()}: set wrapper activity status to off
+
 }}
-
 \author{
 Jan Philipp Dietrich
 }

--- a/man/madratAttach.Rd
+++ b/man/madratAttach.Rd
@@ -19,9 +19,9 @@ universe or detaches it again from it.
 }
 \section{Functions}{
 \itemize{
-\item \code{madratDetach}: detach package from madrat universe
-}}
+\item \code{madratDetach()}: detach package from madrat universe
 
+}}
 \examples{
 \dontrun{
 madratAttach("madrat")

--- a/man/setConfig.Rd
+++ b/man/setConfig.Rd
@@ -137,9 +137,9 @@ you can achieve a reset by setting the value to "".
 }
 \section{Functions}{
 \itemize{
-\item \code{localConfig}: A wrapper for setConfig(..., .local = TRUE)
-}}
+\item \code{localConfig()}: A wrapper for setConfig(..., .local = TRUE)
 
+}}
 \note{
 \code{setConfig} must only be used before the data processing is started and changes in the configuration
 from within a download-, read-, correct-, convert-, calc-, or full-function are not allowed! Only allowed

--- a/tests/testthat/test-vcat-withMadratLogging.R
+++ b/tests/testthat/test-vcat-withMadratLogging.R
@@ -1,8 +1,11 @@
-
 test_that("vcat redirect works", {
   localConfig(verbosity = 1, .verbose = FALSE)
   expect_message(madrat:::cat("blub"), "NOTE: blub")
   expect_message(suppressWarnings(madrat:::warning("blub")), "WARNING: blub")
+})
+
+test_that("vcat can handle lists", {
+  expect_warning(vcat(0, list(a = 3, b = "blub")), "3blub")
 })
 
 # define shortcut for withMadratLogging and a


### PR DESCRIPTION
Calling `vcat(1, list())` was crashing, this PR fixes that. The key was just to deparse lists into character (see first change in vcat.R), the rest is just reducing cyclomatic complexity and linter stuff.