### PR TITLE
Add two alternative country names for Macedonia.

### DIFF
--- a/inst/extdata/country2iso.csv
+++ b/inst/extdata/country2iso.csv
@@ -124,6 +124,8 @@ Eritrea;ERI
 Estonia;EST
 Ethiopia;ETH
 FYR of Macedonia;MKD
+FYROM;MKD
+Macedonia (FYROM);MKD
 Falkland Islands (Malvinas);FLK
 Falkland_Islands_or_Islas_Malvinas;FLK
 Faroe Islands;FRO


### PR DESCRIPTION
Only relevant for the table that supplies `toolCountry2isocode`.