### PR TITLE
fixed vcat behavior

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42536655'
+ValidationKey: '42560358'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "2.20.5",
+  "version": "2.20.6",
   "description": "<p>Provides a framework which should improve reproducibility and\n    transparency in data processing. It provides functionality such as\n    automatic meta data creation and management, rudimentary quality\n    management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this\n    package to deliver everything what is needed to achieve full\n    reproducibility and transparency, but we believe that it supports\n    efforts in this direction.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 2.20.5
-Date: 2022-10-26
+Version: 2.20.6
+Date: 2022-10-28
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = "aut"),

--- a/R/cacheCleanup.R
+++ b/R/cacheCleanup.R
@@ -31,7 +31,7 @@ cacheCleanup <- function(daysThreshold, path = getConfig("cachefolder", verbose 
   }
   local_dir(path)
 
-  cat("Loading file timestamps...")
+  message("Loading file timestamps...")
   filesAccessTimes <- file.info(list.files())
   dateThreshold <- Sys.time() - daysThreshold * 24 * 60 * 60
   oldFiles <- filesAccessTimes[filesAccessTimes[[timeType]] < dateThreshold, ]

--- a/R/downloadSource.R
+++ b/R/downloadSource.R
@@ -93,7 +93,7 @@ downloadSource <- function(type, subtype = NULL, overwrite = FALSE, numberOfTrie
     for (i in seq_len(numberOfTries - 1)) { # -1 because one try was already done before
       argsString <- paste(list(list(type = type, subtype = subtype))) # use paste + list for nicer string output
       argsString <- substr(argsString, 6, nchar(argsString) - 1) # remove superfluous list from string
-      cat("downloadSource(", argsString, ") is already in progress, waiting 30 seconds...")
+      vcat(1, "downloadSource(", argsString, ") is already in progress, waiting 30 seconds...")
       Sys.sleep(30)
       if (dir.exists(typesubtype)) {
         # the parallel running download finished, nothing to do here

--- a/R/getConfig.R
+++ b/R/getConfig.R
@@ -58,7 +58,7 @@ getConfig <- function(option = NULL, raw = FALSE, verbose = TRUE, print = FALSE)
                   "! Access will be disabled soon!")
           break
         } else if (option %in% discouragedOptions[[w]]) {
-          cat("getConfig for option \"", option, "\" should - if possible - be avoided from within ", w, "!")
+          message("getConfig for option \"", option, "\" should - if possible - be avoided from within ", w, "!")
           break
         }
       }

--- a/R/retrieveData.R
+++ b/R/retrieveData.R
@@ -200,7 +200,7 @@ retrieveData <- function(model, rev = 0, dev = "", cachetype = "rev", puc = iden
           vcat(1, " - create puc (", pucPath, ")", fill = 300, show_prefix = FALSE)
           with_tempdir({
             file.copy(cacheFiles, ".")
-            otherFiles <- c("config.rds", "diagnostics.log", "diagnostics_full.log")
+            otherFiles <- c("config.rds", "diagnostics.log")
             file.copy(file.path(outputfolder, otherFiles), ".")
 
             requiredPackages <- attr(cfg$functionName, "package")

--- a/R/setConfig.R
+++ b/R/setConfig.R
@@ -58,8 +58,6 @@
 #' all algorithms supported by \code{\link[digest]{digest}} can be used.
 #' @param diagnostics Either FALSE (default) to avoid the creation of additional
 #' log files or a file name for additional diagnostics information (without file ending).
-#' 2 log files are written if a file name is provided (a compact version with the most
-#' relevant information and a full version with all available details).
 #' @param debug Boolean which activates a debug mode. In debug mode all calculations will
 #' be executed with try=TRUE so that calculations do not stop even if the previous calculation failed.
 #' This can be helpful to get a full picture of errors rather than only seeing the first one. In addition
@@ -197,7 +195,7 @@ setConfig <- function(regionmapping = NULL, # nolint
     options(madrat_cfg = cfg) # nolint
   }
 
-  if (!is.null(info) & .verbose) {
+  if (!is.null(info) && .verbose) {
     for (i in info) vcat(-2, i)
   }
 }

--- a/R/toolCountryFill.R
+++ b/R/toolCountryFill.R
@@ -55,7 +55,7 @@ toolCountryFill <- function(x, fill = NA, no_remove_warning = NULL, overwrite = 
     x <- x[setdiff(getItems(x, dim = 1.1), additionalCountries), , ]
     # warn only for countries which were not explicitly mentioned in argument "remove"
     countries2warn <- setdiff(additionalCountries, no_remove_warning)
-    if (length(countries2warn) > 0) vcat(0, "Data for following unknown country codes removed: ",
+    if (length(countries2warn) > 0) warning("Data for following unknown country codes removed: ",
       paste(countries2warn, collapse = ", "))
   }
 
@@ -71,7 +71,7 @@ toolCountryFill <- function(x, fill = NA, no_remove_warning = NULL, overwrite = 
     if (!all(names(map) %in% missingCountries)) {
       if (overwrite) {
         tmp <- map[!(names(map) %in% missingCountries)]
-        vcat(1, "Existing data overwritten with data from another country (",
+        message("Existing data overwritten with data from another country (",
           paste(tmp, names(tmp), sep = " -> ", collapse = " | "), ").")
       } else {
         map <- map[(names(map) %in% missingCountries)]

--- a/R/toolFillWithRegionAvg.R
+++ b/R/toolFillWithRegionAvg.R
@@ -117,13 +117,13 @@ toolFillWithRegionAvg <- function(x, valueToReplace = NA, weight = NULL, callToo
     }
   }
   if (verbose) {
-    vcat(1, "Replaced missing values with regional average for: ", paste(replace, collapse = ", "))
+    message("Replaced missing values with regional average for: ", paste(replace, collapse = ", "))
   }
   if (length(aboveThreshold$warning) > 0) {
     warning("More than ", 100 * warningThreshold, "% missing values for: ",
             paste(names(aboveThreshold$warning), collapse = ", "))
   } else if (length(aboveThreshold$note) > 0) {
-    vcat(1, "More than ", 100 * noteThreshold, "% missing values for: ",
+    message("More than ", 100 * noteThreshold, "% missing values for: ",
          paste(names(aboveThreshold$note), collapse = ", "))
   }
 

--- a/R/toolISOhistorical.R
+++ b/R/toolISOhistorical.R
@@ -82,7 +82,7 @@ toolISOhistorical <- function(m, mapping = NULL, additional_mapping = NULL, over
     h <- NULL
     fromISOYear <- list()
     for (i in seq_along(ptr[, 1])) {
-      if (!length(mapping$toISO[mapping$fromISO == ptr[i, 1]]) == 1 | i == length(ptr[, 1])) {
+      if (!length(mapping$toISO[mapping$fromISO == ptr[i, 1]]) == 1 || i == length(ptr[, 1])) {
         ntr <- ntr + 1
         fromISOYear[[ntr]] <- cbind(h, ptr[i, ])
         h <- NULL

--- a/R/toolISOhistorical.R
+++ b/R/toolISOhistorical.R
@@ -132,7 +132,7 @@ toolISOhistorical <- function(m, mapping = NULL, additional_mapping = NULL, over
         weight <- setYears(m[a$toISO, a$toY, ], NULL)
         if (anyNA(weight)) {
           weight[is.na(weight)] <- 0
-          vcat(0, "Weight in toolISOhistorical contained NAs. Set NAs to 0!")
+          warning("Weight in toolISOhistorical contained NAs. Set NAs to 0!")
         }
       } else {
         if (!all(a$toISO %in% getItems(additional_weight, dim = 1))) {

--- a/R/vcat.R
+++ b/R/vcat.R
@@ -85,7 +85,6 @@ vcat <- function(verbosity, ..., level = NULL, fill = TRUE,
       preppedMessage <- paste(capture.output(base::cat(c(prefix, messages), fill = fill, sep = "",
                                                        labels = getOption("gdt_nestinglevel"))), collapse = "\n")
       base::message(preppedMessage)
-      base::cat(preppedMessage)
       options(madratWarningsCounter = getOption("madratWarningsCounter", 0) + 1) # nolint
     } else {
       base::message(paste(capture.output(base::cat(c(prefix, messages), fill = fill, sep = "",

--- a/R/vcat.R
+++ b/R/vcat.R
@@ -32,16 +32,33 @@
 #' vcat(2, "Hello world!")
 #' }
 #' @importFrom utils capture.output
-vcat <- function(verbosity, ..., level = NULL, fill = TRUE,
-                 show_prefix = TRUE, logOnly = FALSE) { # nolint
-  # deparse lists to character to prevent `(type 'list') cannot be handled by 'cat'`
-  messages <- lapply(list(...), function(x) if (is.list(x)) deparse(x) else x)
-  messages <- as.character(messages)
+
+vcat <- function(verbosity, ..., level = NULL, fill = TRUE, show_prefix = TRUE, logOnly = FALSE) { # nolint
+
+  # add check functions to detect whether warnings/messages should be suppressed
+  .warningsSuppressed <- function() {
+    supressed <- (length(capture.output(warning(NULL, immediate. = TRUE), type = "message")) == 0)
+    return(supressed)
+  }
+  .messagesSuppressed <- function() {
+    supressed <- (length(capture.output(message(NULL), type = "message")) == 0)
+    return(supressed)
+  }
+
+  .suppressed <- function(verbosity) {
+    if (verbosity == 0) return(.warningsSuppressed())
+    if (verbosity > 0) return(.messagesSuppressed())
+    return(FALSE)
+  }
 
   # make sure that vcat is not run from within another vcat
   if (isWrapperActive("vcat")) return()
   setWrapperActive("vcat")
   setWrapperInactive("wrapperChecks")
+
+  # deparse lists to character to prevent `(type 'list') cannot be handled by 'cat'`
+  messages <- lapply(list(...), function(x) if (is.list(x)) deparse(x) else x)
+  messages <- as.character(messages)
 
   if (!is.null(level)) {
     if (level == 0) {
@@ -57,16 +74,11 @@ vcat <- function(verbosity, ..., level = NULL, fill = TRUE,
   writelog <- is.character(d)
   if (writelog) {
     logfile <- paste0(getConfig("outputfolder"), "/", d, ".log")
-    fulllogfile <- paste0(getConfig("outputfolder"), "/", d, "_full.log")
   }
   prefix <- c("", "ERROR: ", "WARNING: ", "NOTE: ", "MINOR NOTE: ")[min(verbosity, 2) + 3]
   if (prefix == "" || !show_prefix) prefix <- NULL
-  if (writelog && dir.exists(dirname(fulllogfile))) {
-    base::cat(c(prefix, messages), fill = fill, sep = "", labels = getOption("gdt_nestinglevel"),
-              file = fulllogfile, append = TRUE)
-  }
   if (getConfig("verbosity") >= verbosity) {
-    if (writelog && dir.exists(dirname(logfile))) {
+    if (writelog && dir.exists(dirname(logfile)) && !.suppressed(verbosity)) {
       base::cat(c(prefix, messages), fill = fill, sep = "", labels = getOption("gdt_nestinglevel"),
                 file = logfile, append = TRUE)
     }
@@ -82,10 +94,12 @@ vcat <- function(verbosity, ..., level = NULL, fill = TRUE,
       if (!logOnly) {
         base::warning(..., call. = FALSE)
       }
-      preppedMessage <- paste(capture.output(base::cat(c(prefix, messages), fill = fill, sep = "",
-                                                       labels = getOption("gdt_nestinglevel"))), collapse = "\n")
-      base::message(preppedMessage)
-      options(madratWarningsCounter = getOption("madratWarningsCounter", 0) + 1) # nolint
+      if (!.warningsSuppressed() || logOnly) {
+        preppedMessage <- paste(capture.output(base::cat(c(prefix, messages), fill = fill, sep = "",
+                                                         labels = getOption("gdt_nestinglevel"))), collapse = "\n")
+        base::message(preppedMessage)
+        options(madratWarningsCounter = getOption("madratWarningsCounter", 0) + 1) # nolint
+      }
     } else {
       base::message(paste(capture.output(base::cat(c(prefix, messages), fill = fill, sep = "",
                                                    labels = getOption("gdt_nestinglevel"))), collapse = "\n"))

--- a/R/vcat.R
+++ b/R/vcat.R
@@ -82,8 +82,10 @@ vcat <- function(verbosity, ..., level = NULL, fill = TRUE,
       if (!logOnly) {
         base::warning(..., call. = FALSE)
       }
-      base::message(paste(capture.output(base::cat(c(prefix, messages), fill = fill, sep = "",
-                                                   labels = getOption("gdt_nestinglevel"))), collapse = "\n"))
+      preppedMessage <- paste(capture.output(base::cat(c(prefix, messages), fill = fill, sep = "",
+                                                       labels = getOption("gdt_nestinglevel"))), collapse = "\n")
+      base::message(preppedMessage)
+      base::cat(preppedMessage)
       options(madratWarningsCounter = getOption("madratWarningsCounter", 0) + 1) # nolint
     } else {
       base::message(paste(capture.output(base::cat(c(prefix, messages), fill = fill, sep = "",
@@ -95,8 +97,3 @@ vcat <- function(verbosity, ..., level = NULL, fill = TRUE,
     options(gdt_nestinglevel = paste0("~", getOption("gdt_nestinglevel"))) # nolint
   }
 }
-
-# redirect standard messaging functions to vcat
-cat     <- function(...) vcat(1, ...)
-warning <- function(...) vcat(0, ...)
-stop    <- function(...) vcat(-1, ...)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **2.20.5**
+R package **madrat**, version **2.20.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2022). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 2.20.5, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2022). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 2.20.6, <URL: https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2022},
-  note = {R package version 2.20.5},
+  note = {R package version 2.20.6},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/man/setConfig.Rd
+++ b/man/setConfig.Rd
@@ -103,9 +103,7 @@ use compression. TRUE corresponds to gzip compression, and character strings "gz
 all algorithms supported by \code{\link[digest]{digest}} can be used.}
 
 \item{diagnostics}{Either FALSE (default) to avoid the creation of additional
-log files or a file name for additional diagnostics information (without file ending).
-2 log files are written if a file name is provided (a compact version with the most
-relevant information and a full version with all available details).}
+log files or a file name for additional diagnostics information (without file ending).}
 
 \item{debug}{Boolean which activates a debug mode. In debug mode all calculations will
 be executed with try=TRUE so that calculations do not stop even if the previous calculation failed.

--- a/tests/testthat/test-retrieveData.R
+++ b/tests/testthat/test-retrieveData.R
@@ -45,7 +45,7 @@ test_that("set extramapping via setConfig and add it's hash to filename", {
 })
 
 test_that("set extramapping via retrieveData and add it's hash and the hash of the full function to filename", {
-  fullTESTY <- function(dummy=FALSE) {
+  fullTESTY <- function(dummy = FALSE) {
     # this function has a dummy parameter to yield a hash that will also be added to the name of the tgz file
     return()
   }
@@ -109,7 +109,7 @@ test_that("strict mode works", {
     calcOutput("WarningTest", aggregate = FALSE)
   }
   calcWarningTest <- function() {
-    vcat(0, "This is a warning!")
+    warning("This is a warning!")
     return(list(x = as.magpie(1), unit = "1", description = "dummy", isocountries = FALSE))
   }
   globalassign("fullWARNTEST", "calcWarningTest")

--- a/tests/testthat/test-vcat-withMadratLogging.R
+++ b/tests/testthat/test-vcat-withMadratLogging.R
@@ -1,9 +1,3 @@
-test_that("vcat redirect works", {
-  localConfig(verbosity = 1, .verbose = FALSE)
-  expect_message(madrat:::cat("blub"), "NOTE: blub")
-  expect_message(suppressWarnings(madrat:::warning("blub")), "WARNING: blub")
-})
-
 test_that("vcat can handle lists", {
   expect_warning(vcat(0, list(a = 3, b = "blub")), "3blub")
 })
@@ -19,11 +13,11 @@ test_that("withMadratLogging properly logs warnings", {
   wMagExp <- "You are trying to mbind an empty magclass object\\. Is that really intended\\?$"
   w <- "This is a warning"
   wExp <- paste0("^", w, "$")
-  wmExp <- paste0("^WARNING: ", w, "\n$")
+  wmExp <- paste0("WARNING: ", w)
   for (withMadratLoggingX in c(wML1, wML2)) {
     expect_warning(expect_message(withMadratLoggingX(base::warning(w)), wmExp), wExp)
-    expect_warning(expect_message(withMadratLoggingX(warning(w)), wmExp), wExp)
-    expect_warning(expect_message(withMadratLoggingX(vcat(0, w)), wmExp), wExp)
+    withMadratLoggingX(expect_warning(warning(w), wExp))
+    withMadratLoggingX(expect_warning(vcat(0, w), wExp))
     expect_warning(expect_message(withMadratLoggingX(trash <- mbind(p[1:10, , , invert = TRUE], p)), wmMagExp), wMagExp)
   }
 })
@@ -53,4 +47,11 @@ test_that("withMadratLogging properly logs warnings", {
     expect_error(expect_message(withMadratLoggingX(stop(e)), emExp), eExp)
     expect_error(expect_message(withMadratLoggingX(vcat(-1, e)), emExp), eExp)
   }
+})
+
+test_that("vcat warnings and messages can be suppressed", {
+  warningCounter <- getOption("madratWarningsCounter", 0)
+  expect_silent(suppressWarnings(vcat(0, "warning")))
+  expect_identical(getOption("madratWarningsCounter", 0), warningCounter)
+  expect_silent(suppressMessages(vcat(1, "bla")))
 })


### PR DESCRIPTION
- vcat should now properly react on suppressMessages or suppressWarnings statements
- removed diagnostics_full.log as it was containing partly misleading (supposedly) suppressed notes/warnings, use a higher verbosity instead to compute the corresponding, detailed information
- fixed linter warnings