### PR TITLE
Compatibility to old cache files

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42809382'
+ValidationKey: '42837592'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "description": "<p>Provides a framework which should improve reproducibility and\n    transparency in data processing. It provides functionality such as\n    automatic meta data creation and management, rudimentary quality\n    management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this\n    package to deliver everything what is needed to achieve full\n    reproducibility and transparency, but we believe that it supports\n    efforts in this direction.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 2.21.1
-Date: 2023-01-05
+Version: 2.21.2
+Date: 2023-01-09
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = "aut"),

--- a/R/readSource.R
+++ b/R/readSource.R
@@ -80,12 +80,17 @@ readSource <- function(type, subtype = NULL, subset = NULL, # nolint: cyclocomp_
   # try to get from cache and check
   .getFromCache <- function(prefix, type, args, subtype, subset) {
     xList <- cacheGet(prefix = prefix, type = type, args = args)
-    if (!is.null(xList) && prefix == "convert" && magclass::is.magpie(xList$x)) {
-      fname <- paste0(prefix, type, "_", subtype, "_", subset)
-      err <- try(.testISO(magclass::getItems(xList$x, dim = 1.1), functionname = fname), silent = TRUE)
-      if ("try-error" %in% class(err)) {
-        vcat(2, " - cache file corrupt for ", fname, show_prefix = FALSE)
-        xList <- NULL
+    if (!is.null(xList)) {
+      if (!is.list(xList)) {
+        xList <- list(x = xList, class = "magpie")
+      }
+      if (prefix == "convert" && magclass::is.magpie(xList$x)) {
+        fname <- paste0(prefix, type, "_", subtype, "_", subset)
+        err <- try(.testISO(magclass::getItems(xList$x, dim = 1.1), functionname = fname), silent = TRUE)
+        if ("try-error" %in% class(err)) {
+          vcat(2, " - cache file corrupt for ", fname, show_prefix = FALSE)
+          xList <- NULL
+        }
       }
     }
     return(xList)
@@ -184,9 +189,9 @@ readSource <- function(type, subtype = NULL, subset = NULL, # nolint: cyclocomp_
                               type %in% getConfig("forcecache"),
                               paste0(prefix, type) %in% getConfig("forcecache")))
   if (forcecacheActive) {
-    x <- .getFromCache(prefix, type, args, subtype, subset)
-    if (!is.null(x)) {
-      return(x)
+    xList <- .getFromCache(prefix, type, args, subtype, subset)
+    if (!is.null(xList)) {
+      return(if (supplementary) xList else xList$x)
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **2.21.1**
+R package **madrat**, version **2.21.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 2.21.1, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 2.21.2, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2023},
-  note = {R package version 2.21.1},
+  note = {R package version 2.21.2},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/tests/testthat/test-caching.R
+++ b/tests/testthat/test-caching.R
@@ -83,3 +83,16 @@ test_that("Cache naming and identification works correctly", {
   expect_message(readSource("CacheExample", convert = "onlycorrect", subtype = "blub"),
                  "correctCacheExample-F[^-]*.rds")
 })
+
+test_that("non-list cache files are supported for forcecache", {
+  localConfig(cachefolder = withr::local_tempdir(), forcecache = TRUE)
+
+  # write legacy non-list cache file
+  saveRDS(as.magpie(1), file.path(getConfig("cachefolder"), "readCacheExample-Fasdasd.rds"))
+
+  readCacheExample <- function() as.magpie(1)
+  globalassign("readCacheExample")
+
+  expect_identical(readSource("CacheExample", supplementary = TRUE),
+                   list(x = readSource("CacheExample"), class = "magpie"))
+})


### PR DESCRIPTION
The latest madrat update introduced a new cache file format (list) which could lead to problems when loading old cache files with the new madrat via forcecache. This PR solves these issues.