### PR TITLE
Extended aggregation options in toolAggregate and calcOutput

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42837592'
+ValidationKey: '43001400'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "2.21.2",
+  "version": "2.22.0",
   "description": "<p>Provides a framework which should improve reproducibility and\n    transparency in data processing. It provides functionality such as\n    automatic meta data creation and management, rudimentary quality\n    management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this\n    package to deliver everything what is needed to achieve full\n    reproducibility and transparency, but we believe that it supports\n    efforts in this direction.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 2.21.2
-Date: 2023-01-09
+Version: 2.22.0
+Date: 2023-01-13
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = "aut"),

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -406,10 +406,10 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
 }
 
 
-.getMapping <- function(aggregate, type, x) {
+.getMapping <- function(aggregate, type, x) { # nolint: cyclocomp_linter
 
   .items2rel <- function(x) {
-    rel <- data.frame(from = getItems(x, dim = 1), getItems(x, dim = 1, split=TRUE, full = TRUE))
+    rel <- data.frame(from = getItems(x, dim = 1), getItems(x, dim = 1, split = TRUE, full = TRUE))
     return(rel)
   }
 
@@ -425,7 +425,7 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
   }
 
   # check if x is bilateral data
-  if(dim(x)[[1]] == length(getISOlist())^2) {
+  if (dim(x)[[1]] == length(getISOlist())^2) {
     tmp <- expand.grid(getISOlist(), getISOlist(), stringsAsFactors = FALSE)
     bilateralElements <- paste0(tmp[[1]], ".", tmp[[2]])
     bilateral <- setequal(bilateralElements, getItems(x, dim = 1))
@@ -458,13 +458,13 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
     }
     relNames <- union(relNames, colnames(rel[["items2rel"]])[-1])
     # add mapping to regions if countries are present
-    if(setequal(rel[["items2rel"]]$country, getISOlist())) {
-      if(!is.null(rel[["items2rel"]]$region)) rel[["items2rel"]]$region <- NULL
+    if (setequal(rel[["items2rel"]]$country, getISOlist())) {
+      if (!is.null(rel[["items2rel"]]$region)) rel[["items2rel"]]$region <- NULL
       rel[["items2rel"]]$region <- merge(rel[["items2rel"]], rel[[1]], by = "country", sort = FALSE)$region
       # sort region into 2nd place to set it as default aggregation if nothing else is specified (aggregate = TRUE)
       cn <- colnames(rel[["items2rel"]])
-      rel[["items2rel"]] <- rel[["items2rel"]][union(c(cn[1],"region"), cn)]
-    } else if(isTRUE(aggregate)) {
+      rel[["items2rel"]] <- rel[["items2rel"]][union(c(cn[1], "region"), cn)]
+    } else if (isTRUE(aggregate)) {
       stop("Cannot aggregate to regions as mapping is missing!")
     }
   }
@@ -540,6 +540,3 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
   }
   return(list(rel = rel, aggregate = aggregate))
 }
-
-
-

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -528,15 +528,15 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
     tmp <- rel[[1]]
     for (i in 2:length(rel)) {
       # merge two mappings by their column that matched the data (see above; usually the ISO countries) and
-      # append '-remove' to the names of columns in the second mapping that also exist in the first mapping.
-      tmp <- merge(tmp, rel[[i]], by.x = itemCol[[1]], by.y = itemCol[[i]], suffixes = c("", "-remove"))
+      # append '--remove' to the names of columns in the second mapping that also exist in the first mapping.
+      tmp <- merge(tmp, rel[[i]], by.x = itemCol[[1]], by.y = itemCol[[i]], suffixes = c("", "--remove"))
       # find index of columns that will be removed from the merge result
-      ignoredColumnsID <- grep("-remove", colnames(tmp))
+      ignoredColumnsID <- grep("--remove", colnames(tmp))
       # list names of columns that will be removed
-      ignoredColumnsName <- paste(gsub("-remove", "", colnames(tmp)[ignoredColumnsID]), collapse = ", ")
+      ignoredColumnsName <- paste(gsub("--remove", "", colnames(tmp)[ignoredColumnsID]), collapse = ", ")
       vcat(verbosity = 1, "Ignoring column(s) ", ignoredColumnsName, " from ", names(rel[i]),
            " as the column(s) already exist in another mapping.", sep = " ")
-      # remove columns from the merge result tagged with '-remove'
+      # remove columns from the merge result tagged with '--remove'
       tmp <- tmp[, -ignoredColumnsID]
     }
     rel <- tmp

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -314,7 +314,7 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
   note        <- .prepComment(x$note, "note")
 
 
-  if (!identical(aggregate, FALSE)) {
+  if (!isFALSE(aggregate)) {
 
     # select fitting relation mappings and merge them if there is more than one
     if (x$class != "magpie") stop("Aggregation can only be used in combination with x$class=\"magpie\"!")
@@ -339,7 +339,7 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
     if (x$mixed_aggregation) x$aggregationArguments$mixed_aggregation <- TRUE # nolint
 
     x$aggregationArguments$rel <- quote(map$rel)
-    if (aggregate != TRUE) x$aggregationArguments$to <- map$aggregate
+    if (!isTRUE(aggregate))  x$aggregationArguments$to <- map$aggregate
     if (try || getConfig("debug") == TRUE) {
       x$x <- try(do.call(x$aggregationFunction, x$aggregationArguments), silent = TRUE)
       if ("try-error" %in% class(x$x)) {
@@ -406,7 +406,7 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
 }
 
 
-.getMapping <- function(aggregate, type, x) { # nolint: cyclocomp_linter
+.getMapping <- function(aggregate, type, x) { # nolint: cyclocomp_linter.
 
   .items2rel <- function(x) {
     rel <- data.frame(from = getItems(x, dim = 1), getItems(x, dim = 1, split = TRUE, full = TRUE))

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -450,11 +450,22 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
     }
     relNames <- union(relNames, names(rel[[r]]))
   }
+  # add relation map based on spatial subdimensions
   if (!bilateral && ndim(x, dim = 1) > 1) {
     rel[["items2rel"]] <- .items2rel(x)
-    relNames <- union(relNames, strsplit(getSets(x, fulldim = FALSE)[1],"\\.")[[1]])
     if (is.null(rel[["items2rel"]]$global)) {
       rel[["items2rel"]]$global <- "GLO"  # add global column
+    }
+    relNames <- union(relNames, colnames(rel[["items2rel"]])[-1])
+    # add mapping to regions if countries are present
+    if(setequal(rel[["items2rel"]]$country, getISOlist())) {
+      if(!is.null(rel[["items2rel"]]$region)) rel[["items2rel"]]$region <- NULL
+      rel[["items2rel"]]$region <- merge(rel[["items2rel"]], rel[[1]], by = "country", sort = FALSE)$region
+      # sort region into 2nd place to set it as default aggregation if nothing else is specified (aggregate = TRUE)
+      cn <- colnames(rel[["items2rel"]])
+      rel[["items2rel"]] <- rel[["items2rel"]][union(c(cn[1],"region"), cn)]
+    } else if(isTRUE(aggregate)) {
+      stop("Cannot aggregate to regions as mapping is missing!")
     }
   }
 

--- a/R/toolAggregate.R
+++ b/R/toolAggregate.R
@@ -27,8 +27,8 @@
 #' all the elements in x. These elements are mapped to the corresponding values
 #' in another column, as described below (see parameter 'from').
 #' It is possible to not set \code{rel} as long as \code{to} is set and \code{dim}
-#' is chosen approprialtly. In that case the relation mapping is extracted from
-#' the dimnames of the corresponding dimension, e.g. if you data contains a
+#' is chosen appropriately. In that case the relation mapping is extracted from
+#' the dimnames of the corresponding dimension, e.g. if your data contains a
 #' spatial subdimension "country" you can aggregate to countries via
 #' \code{toolAggregate(x, to = "country", dim = 1)}.
 #' @param weight magclass object containing weights which should be considered
@@ -43,8 +43,7 @@
 #' used}). If data should be aggregated based on more than one column these
 #' columns can be specified via "+", e.g. "region+global" if the data should
 #' be aggregated to column regional as well as column global.
-#' If {rel} is missing \code{to} refers to the dimension name to which should
-#' be aggregated to.
+#' If {rel} is missing \code{to} refers to the aggregation target dimension name.
 #' @param dim Specifying the dimension of the magclass object that should be
 #' (dis-)aggregated. Either specified as an integer
 #' (1=spatial,2=temporal,3=data) or if you want to specify a sub dimension

--- a/R/toolAggregate.R
+++ b/R/toolAggregate.R
@@ -90,7 +90,7 @@
 #' toolAggregate(p, mapping, weight = p)
 #' # combined aggregation across two columns
 #' toolAggregate(p, mapping, to = "region+global")
-
+#'
 toolAggregate <- function(x, rel, weight = NULL, from = NULL, to = NULL, dim = 1, wdim = NULL, partrel = FALSE, # nolint
                           negative_weight = "warn", mixed_aggregation = FALSE, verbosity = 1) { # nolint
 
@@ -99,13 +99,13 @@ toolAggregate <- function(x, rel, weight = NULL, from = NULL, to = NULL, dim = 1
   comment <- getComment(x)
 
   # create missing rel information from dimension names if argument "to" is set
-  if(missing(rel) && !is.null(to)) {
-    if(round(dim)!=dim) stop("Subdimensions in dim not supported if relation mapping is missing!")
-    rel <- data.frame(c(dimnames(x)[dim],getItems(x, dim = dim, split = TRUE, full = TRUE)))
+  if (missing(rel) && !is.null(to)) {
+    if (round(dim) != dim) stop("Subdimensions in dim not supported if relation mapping is missing!")
+    rel <- data.frame(c(dimnames(x)[dim], getItems(x, dim = dim, split = TRUE, full = TRUE)))
     if (dim == 1 && is.null(rel$global)) {
       rel$global <- "GLO"  # add global column
     }
-    if(is.null(rel$all)) {
+    if (is.null(rel$all)) {
       rel$all <- "all"
     }
   }
@@ -185,7 +185,7 @@ toolAggregate <- function(x, rel, weight = NULL, from = NULL, to = NULL, dim = 1
       rel <- tmprel
     } else {
       rel <- .getAggregationMatrix(rel, from = from, to = to, items = getItems(x, dim = dim), partrel = partrel)
-      if(is.null(to)) to  <- names(dimnames(rel))[1]
+      if (is.null(to)) to  <- names(dimnames(rel))[1]
     }
   }
 
@@ -394,7 +394,7 @@ toolAggregate <- function(x, rel, weight = NULL, from = NULL, to = NULL, dim = 1
 
     sets <- getSets(x, fulldim = FALSE)
     # update set name if number of sub-dimensions reduced to 1
-    if (ndim(out, dim = dim) == 1  && ndim(x, dim = dim) > 1)  {
+    if (ndim(out, dim = dim) == 1  && ndim(x, dim = dim) > 1) {
       sets[dim] <- ifelse(!is.null(to), to, NA)
     }
     getSets(out, fulldim = FALSE) <- sets

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **2.21.2**
+R package **madrat**, version **2.22.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 2.21.2, <https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 2.22.0, <URL: https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2023},
-  note = {R package version 2.21.2},
+  note = {R package version 2.22.0},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/man/toolAggregate.Rd
+++ b/man/toolAggregate.Rd
@@ -27,8 +27,8 @@ A mapping object consists of any number of columns, where one column contains
 all the elements in x. These elements are mapped to the corresponding values
 in another column, as described below (see parameter 'from').
 It is possible to not set \code{rel} as long as \code{to} is set and \code{dim}
-is chosen approprialtly. In that case the relation mapping is extracted from
-the dimnames of the corresponding dimension, e.g. if you data contains a
+is chosen appropriately. In that case the relation mapping is extracted from
+the dimnames of the corresponding dimension, e.g. if your data contains a
 spatial subdimension "country" you can aggregate to countries via
 \code{toolAggregate(x, to = "country", dim = 1)}.}
 
@@ -46,8 +46,7 @@ If column \code{from} is the last column, the column before \code{from is
 used}). If data should be aggregated based on more than one column these
 columns can be specified via "+", e.g. "region+global" if the data should
 be aggregated to column regional as well as column global.
-If {rel} is missing \code{to} refers to the dimension name to which should
-be aggregated to.}
+If {rel} is missing \code{to} refers to the aggregation target dimension name.}
 
 \item{dim}{Specifying the dimension of the magclass object that should be
 (dis-)aggregated. Either specified as an integer

--- a/man/toolAggregate.Rd
+++ b/man/toolAggregate.Rd
@@ -25,7 +25,12 @@ toolAggregate(
 supported by \code{\link{toolGetMapping}} (currently csv, rds or rda).
 A mapping object consists of any number of columns, where one column contains
 all the elements in x. These elements are mapped to the corresponding values
-in another column, as described below (see parameter 'from').}
+in another column, as described below (see parameter 'from').
+It is possible to not set \code{rel} as long as \code{to} is set and \code{dim}
+is chosen approprialtly. In that case the relation mapping is extracted from
+the dimnames of the corresponding dimension, e.g. if you data contains a
+spatial subdimension "country" you can aggregate to countries via
+\code{toolAggregate(x, to = "country", dim = 1)}.}
 
 \item{weight}{magclass object containing weights which should be considered
 for a weighted aggregation. The provided weight should only contain positive
@@ -40,7 +45,9 @@ mapping (if not set the column following column \code{from} will be used
 If column \code{from} is the last column, the column before \code{from is
 used}). If data should be aggregated based on more than one column these
 columns can be specified via "+", e.g. "region+global" if the data should
-be aggregated to column regional as well as column global.}
+be aggregated to column regional as well as column global.
+If {rel} is missing \code{to} refers to the dimension name to which should
+be aggregated to.}
 
 \item{dim}{Specifying the dimension of the magclass object that should be
 (dis-)aggregated. Either specified as an integer

--- a/man/toolAggregate.Rd
+++ b/man/toolAggregate.Rd
@@ -114,6 +114,7 @@ toolAggregate(p, mapping)
 toolAggregate(p, mapping, weight = p)
 # combined aggregation across two columns
 toolAggregate(p, mapping, to = "region+global")
+
 }
 \seealso{
 \code{\link{calcOutput}}

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -220,6 +220,7 @@ test_that("Aggregation works", {
   }
   calcAggregationTest3 <- function() {
     x1 <- new.magpie(getISOlist(), fill = 1)
+    getSets(x1)[1] <- "country"
     x2 <- new.magpie(1:4, fill = 2)
     x <- x1*x2
     return(list(x = x,
@@ -259,21 +260,21 @@ test_that("Aggregation works", {
               .Dimnames = list(region = "GLO", year = NULL, data = NULL)))
 
   country2 <- new("magpie", .Data = structure(rep(8, 249), .Dim = c(249L, 1L, 1L), .Dimnames = list(
-    region = unname(getISOlist()), year = NULL, data = NULL)))
+    country = unname(getISOlist()), year = NULL, data = NULL)))
 
   reg2 <- new("magpie", .Data = structure(c(432, 392, 408, 272, 128, 168,
                                             96, 40, 32, 8, 8, 8), .Dim = c(12L, 1L, 1L), .Dimnames = list(
                                             region = c("LAM", "OAS", "SSA", "EUR", "NEU", "MEA", "REF",
                                                        "CAZ", "CHA", "IND", "JPN", "USA"), year = NULL, data = NULL)))
   glo2 <- new("magpie", .Data = structure(1992, .Dim = c(1L, 1L, 1L),
-                                          .Dimnames = list(region = "GLO", year = NULL, data = NULL)))
+                                          .Dimnames = list(global = "GLO", year = NULL, data = NULL)))
 
   expect_identical(nc(calcOutput("AggregationTest")), reg)
   expect_identical(nc(calcOutput("AggregationTest2")), clean_magpie(as.magpie(1)))
-  #expect_identical(nc(calcOutput("AggregationTest3")), reg2)
+  expect_identical(nc(calcOutput("AggregationTest3")), reg2)
   expect_identical(nc(calcOutput("AggregationTest", aggregate = "glo")), glo)
   expect_identical(nc(calcOutput("AggregationTest3", aggregate = "glo")), glo2)
-  #expect_identical(nc(calcOutput("AggregationTest3", aggregate = "country")), country2)
+  expect_identical(nc(calcOutput("AggregationTest3", aggregate = "country")), country2)
   expect_identical(nc(calcOutput("AggregationTest", aggregate = "regglo")), mbind(reg, glo))
   expect_warning(a <- nc(calcOutput("AggregationTest", aggregate = "global+region+cheese")),
                  "Omitting cheese from aggregate")

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -222,7 +222,7 @@ test_that("Aggregation works", {
     x1 <- new.magpie(getISOlist(), fill = 1)
     getSets(x1)[1] <- "country"
     x2 <- new.magpie(1:4, fill = 2)
-    x <- x1*x2
+    x <- x1 * x2
     return(list(x = x,
                 weight = NULL,
                 description = "Aggregation test data 3",
@@ -232,7 +232,7 @@ test_that("Aggregation works", {
     x1 <- new.magpie(getISOlist()[1:12], fill = 1)
     getSets(x1)[1] <- "country"
     x2 <- new.magpie(1:4, fill = 2)
-    x <- x1*x2
+    x <- x1 * x2
     return(list(x = x,
                 weight = NULL,
                 description = "Aggregation test data 3",
@@ -290,7 +290,7 @@ test_that("Aggregation works", {
   expect_identical(nc(calcOutput("AggregationTest", aggregate = "glo")), glo)
   expect_identical(nc(calcOutput("AggregationTest3", aggregate = "glo")), glo2)
   expect_identical(nc(calcOutput("AggregationTest3", aggregate = "country")), country2)
-  expect_error(calcOutput("AggregationTest4", aggregate =TRUE), "Cannot aggregate to regions")
+  expect_error(calcOutput("AggregationTest4", aggregate = TRUE), "Cannot aggregate to regions")
   expect_identical(nc(calcOutput("AggregationTest4", aggregate = "region1")), region1)
   expect_identical(nc(calcOutput("AggregationTest", aggregate = "regglo")), mbind(reg, glo))
   expect_warning(a <- nc(calcOutput("AggregationTest", aggregate = "global+region+cheese")),

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -270,10 +270,10 @@ test_that("Aggregation works", {
 
   expect_identical(nc(calcOutput("AggregationTest")), reg)
   expect_identical(nc(calcOutput("AggregationTest2")), clean_magpie(as.magpie(1)))
-  expect_identical(nc(calcOutput("AggregationTest3")), reg2)
+  #expect_identical(nc(calcOutput("AggregationTest3")), reg2)
   expect_identical(nc(calcOutput("AggregationTest", aggregate = "glo")), glo)
   expect_identical(nc(calcOutput("AggregationTest3", aggregate = "glo")), glo2)
-  expect_identical(nc(calcOutput("AggregationTest3", aggregate = "country")), country2)
+  #expect_identical(nc(calcOutput("AggregationTest3", aggregate = "country")), country2)
   expect_identical(nc(calcOutput("AggregationTest", aggregate = "regglo")), mbind(reg, glo))
   expect_warning(a <- nc(calcOutput("AggregationTest", aggregate = "global+region+cheese")),
                  "Omitting cheese from aggregate")

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -218,6 +218,15 @@ test_that("Aggregation works", {
                 mixed_aggregation = TRUE,
                 aggregationFunction = function(x, rel, mixed_aggregation) return(as.magpie(1)))) # nolint
   }
+  calcAggregationTest3 <- function() {
+    x1 <- new.magpie(getISOlist(), fill = 1)
+    x2 <- new.magpie(1:4, fill = 2)
+    x <- x1*x2
+    return(list(x = x,
+                weight = NULL,
+                description = "Aggregation test data 3",
+                unit = "1"))
+  }
   calcMalformedAggregation <- function() {
     x <- new.magpie(getISOlist(), fill = 1)
     return(list(x = x,
@@ -237,7 +246,7 @@ test_that("Aggregation works", {
                 aggregationArguments = 42,
                 aggregationFunction = function(x, rel, mixed_aggregation) return(as.magpie(1)))) # nolint
   }
-  globalassign("calcAggregationTest", "calcAggregationTest2",
+  globalassign("calcAggregationTest", "calcAggregationTest2", "calcAggregationTest3",
                "calcMalformedAggregation", "calcMalformedAggregation2")
 
   reg <- new("magpie", .Data = structure(c(54, 49, 51, 34, 16, 21, 12,
@@ -249,9 +258,22 @@ test_that("Aggregation works", {
   glo <- new("magpie", .Data = structure(249, .Dim = c(1L, 1L, 1L),
               .Dimnames = list(region = "GLO", year = NULL, data = NULL)))
 
+  country2 <- new("magpie", .Data = structure(rep(8, 249), .Dim = c(249L, 1L, 1L), .Dimnames = list(
+    region = unname(getISOlist()), year = NULL, data = NULL)))
+
+  reg2 <- new("magpie", .Data = structure(c(432, 392, 408, 272, 128, 168,
+                                            96, 40, 32, 8, 8, 8), .Dim = c(12L, 1L, 1L), .Dimnames = list(
+                                            region = c("LAM", "OAS", "SSA", "EUR", "NEU", "MEA", "REF",
+                                                       "CAZ", "CHA", "IND", "JPN", "USA"), year = NULL, data = NULL)))
+  glo2 <- new("magpie", .Data = structure(1992, .Dim = c(1L, 1L, 1L),
+                                          .Dimnames = list(region = "GLO", year = NULL, data = NULL)))
+
   expect_identical(nc(calcOutput("AggregationTest")), reg)
   expect_identical(nc(calcOutput("AggregationTest2")), clean_magpie(as.magpie(1)))
+  expect_identical(nc(calcOutput("AggregationTest3")), reg2)
   expect_identical(nc(calcOutput("AggregationTest", aggregate = "glo")), glo)
+  expect_identical(nc(calcOutput("AggregationTest3", aggregate = "glo")), glo2)
+  expect_identical(nc(calcOutput("AggregationTest3", aggregate = "country")), country2)
   expect_identical(nc(calcOutput("AggregationTest", aggregate = "regglo")), mbind(reg, glo))
   expect_warning(a <- nc(calcOutput("AggregationTest", aggregate = "global+region+cheese")),
                  "Omitting cheese from aggregate")

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -228,6 +228,17 @@ test_that("Aggregation works", {
                 description = "Aggregation test data 3",
                 unit = "1"))
   }
+  calcAggregationTest4 <- function() {
+    x1 <- new.magpie(getISOlist()[1:12], fill = 1)
+    getSets(x1)[1] <- "country"
+    x2 <- new.magpie(1:4, fill = 2)
+    x <- x1*x2
+    return(list(x = x,
+                weight = NULL,
+                description = "Aggregation test data 3",
+                unit = "1",
+                isocountries = FALSE))
+  }
   calcMalformedAggregation <- function() {
     x <- new.magpie(getISOlist(), fill = 1)
     return(list(x = x,
@@ -247,7 +258,7 @@ test_that("Aggregation works", {
                 aggregationArguments = 42,
                 aggregationFunction = function(x, rel, mixed_aggregation) return(as.magpie(1)))) # nolint
   }
-  globalassign("calcAggregationTest", "calcAggregationTest2", "calcAggregationTest3",
+  globalassign("calcAggregationTest", "calcAggregationTest2", "calcAggregationTest3", "calcAggregationTest4",
                "calcMalformedAggregation", "calcMalformedAggregation2")
 
   reg <- new("magpie", .Data = structure(c(54, 49, 51, 34, 16, 21, 12,
@@ -269,12 +280,18 @@ test_that("Aggregation works", {
   glo2 <- new("magpie", .Data = structure(1992, .Dim = c(1L, 1L, 1L),
                                           .Dimnames = list(global = "GLO", year = NULL, data = NULL)))
 
+  region1 <- new("magpie", .Data = structure(rep(24, 4), .Dim = c(4L, 1L, 1L),
+                                             .Dimnames = list(region1 = c("1", "2", "3", "4"),
+                                                              year = NULL, data = NULL)))
+
   expect_identical(nc(calcOutput("AggregationTest")), reg)
   expect_identical(nc(calcOutput("AggregationTest2")), clean_magpie(as.magpie(1)))
   expect_identical(nc(calcOutput("AggregationTest3")), reg2)
   expect_identical(nc(calcOutput("AggregationTest", aggregate = "glo")), glo)
   expect_identical(nc(calcOutput("AggregationTest3", aggregate = "glo")), glo2)
   expect_identical(nc(calcOutput("AggregationTest3", aggregate = "country")), country2)
+  expect_error(calcOutput("AggregationTest4", aggregate =TRUE), "Cannot aggregate to regions")
+  expect_identical(nc(calcOutput("AggregationTest4", aggregate = "region1")), region1)
   expect_identical(nc(calcOutput("AggregationTest", aggregate = "regglo")), mbind(reg, glo))
   expect_warning(a <- nc(calcOutput("AggregationTest", aggregate = "global+region+cheese")),
                  "Omitting cheese from aggregate")

--- a/tests/testthat/test-toolAggregate.R
+++ b/tests/testthat/test-toolAggregate.R
@@ -16,7 +16,7 @@ cfg <- getConfig(verbose = FALSE)
 
 noC <- function(x) {
   getComment(x) <- NULL
-  attr(x, "Metadata") <- NULL # nolint: object_name_linter
+  attr(x, "Metadata") <- NULL # nolint: object_name_linter.
   return(x)
 }
 

--- a/tests/testthat/test-toolAggregate.R
+++ b/tests/testthat/test-toolAggregate.R
@@ -16,7 +16,7 @@ cfg <- getConfig(verbose = FALSE)
 
 noC <- function(x) {
   getComment(x) <- NULL
-  attr(x, "Metadata") <- NULL
+  attr(x, "Metadata") <- NULL # nolint: object_name_linter
   return(x)
 }
 
@@ -169,9 +169,9 @@ test_that("aggregation for subdimensions works properly", {
 test_that("aggregation with missing rel argument works", {
   a <- magclass::maxample("animal")
   rel <- data.frame(from = getItems(a, dim = 1), country = getItems(a, dim = "country", full = TRUE), global = "GLO")
-  expect_identical(noC(toolAggregate(a, to="country")), noC(toolAggregate(a, rel)))
-  expect_identical(noC(  toolAggregate(a, to="global+country")), noC(  toolAggregate(a, to="global+country")))
-  expect_identical(noC(toolAggregate(a, to = "species", dim = 3)), noC(dimSums(a, dim =c(3.1,3.3))))
+  expect_identical(noC(toolAggregate(a, to = "country")), noC(toolAggregate(a, rel)))
+  expect_identical(noC(toolAggregate(a, to = "global+country")), noC(toolAggregate(a, to = "global+country")))
+  expect_identical(noC(toolAggregate(a, to = "species", dim = 3)), noC(dimSums(a, dim = c(3.1, 3.3))))
   aSum <- dimSums(a, dim = 3)
   getSets(aSum, fulldim = FALSE)[3] <- "all"
   getItems(aSum, dim = 3) <- "all"
@@ -193,7 +193,7 @@ test_that("Malformed inputs are properly detected", {
   expect_warning(toolAggregate(pm, map, weight = -pm), "Negative numbers in weight.")
   expect_error(toolAggregate(pm, map, weight = -pm, negative_weight = "stop"), "Negative numbers in weight.")
   expect_error(toolAggregate(pm, diag(1, 16, 16), dim = 2), "Missing dimnames for aggregated dimension")
-  expect_error(toolAggregate(magclass::maxample("animal"), to="country", dim = 1.2),
+  expect_error(toolAggregate(magclass::maxample("animal"), to = "country", dim = 1.2),
                "Subdimensions in dim not supported if relation mapping is missing!")
 })
 

--- a/tests/testthat/test-toolAggregate.R
+++ b/tests/testthat/test-toolAggregate.R
@@ -166,6 +166,19 @@ test_that("aggregation for subdimensions works properly", {
   expect_identical(getItems(toolAggregate(a, rel, dim = "species"), dim = 3, full = TRUE), "animal.sweet.black")
 })
 
+test_that("aggregation with missing rel argument works", {
+  a <- magclass::maxample("animal")
+  rel <- data.frame(from = getItems(a, dim = 1), country = getItems(a, dim = "country", full = TRUE), global = "GLO")
+  expect_identical(noC(toolAggregate(a, to="country")), noC(toolAggregate(a, rel)))
+  expect_identical(noC(  toolAggregate(a, to="global+country")), noC(  toolAggregate(a, to="global+country")))
+  expect_identical(noC(toolAggregate(a, to = "species", dim = 3)), noC(dimSums(a, dim =c(3.1,3.3))))
+  aSum <- dimSums(a, dim = 3)
+  getSets(aSum, fulldim = FALSE)[3] <- "all"
+  getItems(aSum, dim = 3) <- "all"
+  expect_identical(noC(toolAggregate(a, to = "all", dim = 3)), noC(aSum))
+  expect_equivalent(toolAggregate(a, to = "global"), toolAggregate(a, to = "all"))
+})
+
 test_that("Malformed inputs are properly detected", {
   expect_error(toolAggregate(1, 2), "Input is not a MAgPIE object")
   expect_error(toolAggregate(pm, map, weight = 1), "Weight is not a MAgPIE object")
@@ -180,6 +193,8 @@ test_that("Malformed inputs are properly detected", {
   expect_warning(toolAggregate(pm, map, weight = -pm), "Negative numbers in weight.")
   expect_error(toolAggregate(pm, map, weight = -pm, negative_weight = "stop"), "Negative numbers in weight.")
   expect_error(toolAggregate(pm, diag(1, 16, 16), dim = 2), "Missing dimnames for aggregated dimension")
+  expect_error(toolAggregate(magclass::maxample("animal"), to="country", dim = 1.2),
+               "Subdimensions in dim not supported if relation mapping is missing!")
 })
 
 test_that("Edge cases work", {


### PR DESCRIPTION
This PR comes with a bunch of improvements in toolAggregate and calcOutput:

* `toolAggregate` now works also in cases in which a relation map `rel` is not specified but the information can be retrieved from the subdimensions of the object
* setNames are now properly set in `toolAggregate` in cases in which the number of subdimensions in reduced during aggregation (e.g. mapping all subdimensions in dim = 1 to only a single spatial dimension)
* `calcOutput` can now aggregate cellular data to regions via `aggregate = TRUE` if the data comes with a spatial "country" subdimension containing all iso countries
*`calcOutput` can now aggregate directly to the spatial subdimensions of the returned object (similar to `toolAggregate`)