### PR TITLE
create config folders

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42837592'
+ValidationKey: '42870236'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "description": "<p>Provides a framework which should improve reproducibility and\n    transparency in data processing. It provides functionality such as\n    automatic meta data creation and management, rudimentary quality\n    management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this\n    package to deliver everything what is needed to achieve full\n    reproducibility and transparency, but we believe that it supports\n    efforts in this direction.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 2.21.2
-Date: 2023-01-09
+Version: 2.21.3
+Date: 2023-01-15
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,9 @@ lint:           ## Check if code etiquette is followed using lucode2::lint()
 
 format:         ## Apply auto-formatting to changed files and lint afterwards
 	Rscript -e 'lucode2::autoFormat()'
+
+install:        ## Install the package locally via devtools::install()
+	Rscript -e 'devtools::install()'
+
+docs:           ## Generate the package documentation via roxygen2::roxygenize()
+	Rscript -e 'roxygen2::roxygenize()'

--- a/R/getConfig.R
+++ b/R/getConfig.R
@@ -68,20 +68,25 @@ getConfig <- function(option = NULL, raw = FALSE, verbose = TRUE, print = FALSE)
   cfg <- getOption("madrat_cfg")
   cfg$mainfolder <- sub("/$", "", cfg$mainfolder)
 
-  n <- c(sourcefolder = "sources", cachefolder = "cache/default", mappingfolder = "mappings",
-         outputfolder = "output", pucfolder = "puc", tmpfolder = "tmp")
-  for (p in names(n)) {
-    if (!raw && (is.null(cfg[[p]]) || is.na(cfg[[p]]))) cfg[[p]] <- file.path(cfg$mainfolder, n[p])
+  if (!raw) {
+    folders <- c(sourcefolder = "sources", cachefolder = "cache/default", mappingfolder = "mappings",
+                outputfolder = "output", pucfolder = "puc", tmpfolder = "tmp")
+    for (folderName in names(folders)) {
+      if (is.null(cfg[[folderName]]) || is.na(cfg[[folderName]])) {
+        cfg[[folderName]] <- file.path(cfg$mainfolder, folders[folderName])
+      }
+      dir.create(cfg[[folderName]], showWarnings = FALSE, recursive = TRUE)
+    }
   }
   if (verbose && print) {
     nmax <- max(nchar(names(cfg)))
     vcat(1, "", show_prefix = FALSE)
     vcat(1, "Current madrat configuration:", show_prefix = FALSE)
-    for (n in names(cfg)) {
-      quotes <- ifelse(is.character(cfg[[n]]), "\"", "")
-      value <- cfg[[n]]
+    for (configName in names(cfg)) {
+      quotes <- ifelse(is.character(cfg[[configName]]), "\"", "")
+      value <- cfg[[configName]]
       if (is.null(value)) value <- "NULL"
-      vcat(1, paste0("   ", format(n, width = nmax), " -> ",
+      vcat(1, paste0("   ", format(configName, width = nmax), " -> ",
                      paste0(quotes, value, quotes, collapse = ", ")), show_prefix = FALSE)
     }
     vcat(1, "", show_prefix = FALSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **2.21.2**
+R package **madrat**, version **2.21.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 2.21.2, <https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 2.21.3, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2023},
-  note = {R package version 2.21.2},
+  note = {R package version 2.21.3},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }


### PR DESCRIPTION
I ran into a problem where `getConfig("tmpfolder")` did not exist. With this PR `getConfig` will create a folder before returning a path to it.