### PR TITLE
fix retrieveData leftover folder/log

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '43008060'
+ValidationKey: '43029654'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "madrat: May All Data be Reproducible and Transparent (MADRaT) *",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "description": "<p>Provides a framework which should improve reproducibility and\n    transparency in data processing. It provides functionality such as\n    automatic meta data creation and management, rudimentary quality\n    management, data caching, work-flow management and data aggregation.\n    * The title is a wish not a promise. By no means we expect this\n    package to deliver everything what is needed to achieve full\n    reproducibility and transparency, but we believe that it supports\n    efforts in this direction.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 2.22.0
-Date: 2023-01-16
+Version: 2.22.1
+Date: 2023-01-17
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ format:         ## Apply auto-formatting to changed files and lint afterwards
 	Rscript -e 'lucode2::autoFormat()'
 
 install:        ## Install the package locally via devtools::install()
-	Rscript -e 'devtools::install(upgrade = "never")'
+	Rscript -e 'devtools::install()'
 
 docs:           ## Generate the package documentation via roxygen2::roxygenize()
 	Rscript -e 'roxygen2::roxygenize()'

--- a/R/retrieveData.R
+++ b/R/retrieveData.R
@@ -242,12 +242,11 @@ retrieveData <- function(model, rev = 0, dev = "", cachetype = "rev", puc = iden
     }
   }
 
+  toolendmessage(startinfo)
   with_dir(outputfolder, {
     suppressWarnings(tar(file.path("..", paste0(cfg$collectionName, ".tgz")), compression = "gzip"))
   })
   unlink(outputfolder, recursive = TRUE)
-
-  toolendmessage(startinfo)
 }
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **2.22.0**
+R package **madrat**, version **2.22.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 2.22.0, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Kreidenweis U, Klein D, Führlich P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 2.22.1, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Ulrich Kreidenweis and David Klein and Pascal Führlich},
   year = {2023},
-  note = {R package version 2.22.0},
+  note = {R package version 2.22.1},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/tests/testthat/test-retrieveData.R
+++ b/tests/testthat/test-retrieveData.R
@@ -1,6 +1,7 @@
 test_that("retrieveData works as expected", {
   expect_message(retrieveData("example", rev = 0, dev = "test"), "Run retrieveData")
   expect_true(file.exists(paste0(getConfig("outputfolder"), "/rev0test_h12_5c275ce3_example_customizable_tag.tgz")))
+  expect_false(dir.exists(file.path(getConfig("outputfolder"), "rev0test_h12_5c275ce3_example")))
   expect_message(retrieveData("example", rev = 0, dev = "test"), "data is already available")
 })
 


### PR DESCRIPTION
retrieveData was writing to the diagnostics log (thus recreating the outputfolder) after the tgz was created and the outputfolder already deleted. This PR fixes that.