### PR TITLE
fix codelabels in pucAggregate

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '7208614'
+ValidationKey: '7228624'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.6.7
-date-released: '2023-10-12'
+version: 3.6.8
+date-released: '2023-10-13'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management
@@ -38,9 +38,9 @@ authors:
 - family-names: Klein
   given-names: David
   email: dklein@pik-potsdam.de
-- family-names: Führlich
+- family-names: Sauer
   given-names: Pascal
-  email: pascal.fuehrlich@pik-potsdam.de
+  email: pascal.sauer@pik-potsdam.de
 license: BSD-2-Clause
 repository-code: https://github.com/pik-piam/madrat
 doi: 10.5281/zenodo.1115490

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.6.7
-Date: 2023-10-12
+Version: 3.6.8
+Date: 2023-10-13
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = "aut"),
@@ -13,7 +13,7 @@ Authors@R: c(
     person("Debbora", "Leip", , "leip@pik-potsdam.de", role = "aut"),
     person("Ulrich", "Kreidenweis", , "kreidenweis@pik-potsdam.de", role = "aut"),
     person("David", "Klein", , "dklein@pik-potsdam.de", role = "aut"),
-    person("Pascal", "Führlich", , "pascal.fuehrlich@pik-potsdam.de", role = "aut")
+    person("Pascal", "Sauer", , "pascal.sauer@pik-potsdam.de", role = "aut")
   )
 Description: Provides a framework which should improve reproducibility and
     transparency in data processing. It provides functionality such as

--- a/R/compareMadratOutputs.R
+++ b/R/compareMadratOutputs.R
@@ -26,7 +26,7 @@
 #' compareMadratOutputs("madrat", "readTau", c("paper", "historical"))
 #' }
 #'
-#' @author Pascal Führlich
+#' @author Pascal Sauer
 #'
 #' @importFrom digest digest
 #' @importFrom magclass where

--- a/R/downloadSource.R
+++ b/R/downloadSource.R
@@ -35,7 +35,7 @@
 #' }
 #' Besides the names above (user-provided and automatically derived) it is possible to add custom metadata entries by
 #' extending the return list with additional, named entries.
-#' @author Jan Philipp Dietrich, David Klein, Pascal Führlich
+#' @author Jan Philipp Dietrich, David Klein, Pascal Sauer
 #' @examples
 #' \dontrun{
 #' a <- downloadSource("Tau", subtype = "historical")

--- a/R/fingerprint.R
+++ b/R/fingerprint.R
@@ -27,7 +27,7 @@
 #' @param ... Additional arguments for \code{\link{getMadratGraph}} in case
 #' that no graph is provided (otherwise ignored)
 #' @return A fingerprint (hash) of all provided sources, or "fingerprintError"
-#' @author Jan Philipp Dietrich, Pascal Führlich
+#' @author Jan Philipp Dietrich, Pascal Sauer
 #' @seealso \code{\link{readSource}}
 #' @examples
 #' madrat:::fingerprint("toolGetMapping", package = "madrat")
@@ -36,52 +36,51 @@
 fingerprint <- function(name, details = FALSE, graph = NULL, ...) {
   dependencies <- getDependencies(name, direction = "in", self = TRUE, graph = graph, ...)
   result <- tryCatch({
-      fingerprintFunctions <- dependencies$hash[robustOrder(dependencies$call)]
-      names(fingerprintFunctions) <- dependencies$call[robustOrder(dependencies$call)]
+    fingerprintFunctions <- dependencies$hash[robustOrder(dependencies$call)]
+    names(fingerprintFunctions) <- dependencies$call[robustOrder(dependencies$call)]
 
-      # handle special requests via flags
-      .tmp <- function(x) {
-        return(robustSort(sub(":+", ":::", x)))
-      }
-      ignore <- .tmp(attr(dependencies, "flags")$ignore)
-      monitor <- .tmp(attr(dependencies, "flags")$monitor)
-      # if conflicting information is giving (monitor and ignore at the same time,
-      # prioritize monitor request)
-      ignore <- setdiff(ignore, monitor)
-      # add calls from the monitor list which are not already monitored
-      fingerprintMonitored <- fingerprintCall(setdiff(monitor, names(fingerprintFunctions)))
-      # ignore functions mentioned in the ignore list
-      fingerprintFunctions <- fingerprintFunctions[setdiff(names(fingerprintFunctions), ignore)]
-      sources <- substring(dependencies$func[dependencies$type == "read"], 5)
-      if (length(sources) > 0) {
-        sources <- paste0(getConfig("sourcefolder"), "/", robustSort(sources))
-      }
-      fingerprintSources <- fingerprintFiles(sources)
-      fingerprintMappings <- fingerprintFiles(attr(dependencies, "mappings"))
-      fingerprint <- c(fingerprintFunctions, fingerprintSources, fingerprintMappings, fingerprintMonitored)
-      fingerprint <- fingerprint[robustOrder(basename(names(fingerprint)))]
-
-      # Cache files became incompatible when readSource was allowed to return non-magpie objects.
-      # Referring to madrat versions before this change as "old" and after this change as "new" here:
-      # Hashing the string "v2" leads to completely new hashes, and thus cache files with different names.
-      # Old madrat versions will never read/write these new cache files, and new madrat versions will never
-      # read/write cache files created with an old madrat version.
-      out <- digest(list("v2", unname(fingerprint)), algo = getConfig("hash"))
-
-      if (details) {
-        attr(out, "details") <- fingerprint
-        vcat(3, "hash components (", out, "):", show_prefix = FALSE)
-        for (n in names(fingerprint)) {
-          vcat(3, "  ", fingerprint[n], " | ", basename(n), " | ", n, show_prefix = FALSE)
-        }
-      }
-      out
-    },
-    error = function(error) {
-      vcat(2, paste(" - Fingerprinting failed:", error), show_prefix = FALSE)
-      return("fingerprintError")
+    # handle special requests via flags
+    .tmp <- function(x) {
+      return(robustSort(sub(":+", ":::", x)))
     }
-  )
+    ignore <- .tmp(attr(dependencies, "flags")$ignore)
+    monitor <- .tmp(attr(dependencies, "flags")$monitor)
+    # if conflicting information is giving (monitor and ignore at the same time,
+    # prioritize monitor request)
+    ignore <- setdiff(ignore, monitor)
+    # add calls from the monitor list which are not already monitored
+    fingerprintMonitored <- fingerprintCall(setdiff(monitor, names(fingerprintFunctions)))
+    # ignore functions mentioned in the ignore list
+    fingerprintFunctions <- fingerprintFunctions[setdiff(names(fingerprintFunctions), ignore)]
+    sources <- substring(dependencies$func[dependencies$type == "read"], 5)
+    if (length(sources) > 0) {
+      sources <- paste0(getConfig("sourcefolder"), "/", robustSort(sources))
+    }
+    fingerprintSources <- fingerprintFiles(sources)
+    fingerprintMappings <- fingerprintFiles(attr(dependencies, "mappings"))
+    fingerprint <- c(fingerprintFunctions, fingerprintSources, fingerprintMappings, fingerprintMonitored)
+    fingerprint <- fingerprint[robustOrder(basename(names(fingerprint)))]
+
+    # Cache files became incompatible when readSource was allowed to return non-magpie objects.
+    # Referring to madrat versions before this change as "old" and after this change as "new" here:
+    # Hashing the string "v2" leads to completely new hashes, and thus cache files with different names.
+    # Old madrat versions will never read/write these new cache files, and new madrat versions will never
+    # read/write cache files created with an old madrat version.
+    out <- digest(list("v2", unname(fingerprint)), algo = getConfig("hash"))
+
+    if (details) {
+      attr(out, "details") <- fingerprint
+      vcat(3, "hash components (", out, "):", show_prefix = FALSE)
+      for (n in names(fingerprint)) {
+        vcat(3, "  ", fingerprint[n], " | ", basename(n), " | ", n, show_prefix = FALSE)
+      }
+    }
+    out
+  },
+  error = function(error) {
+    vcat(2, paste(" - Fingerprinting failed:", error), show_prefix = FALSE)
+    return("fingerprintError")
+  })
   attr(result, "call") <- dependencies$call[dependencies$func == name]
   return(result)
 }
@@ -135,7 +134,7 @@ fingerprintFiles <- function(paths) {
       # return file name for fileHash cache if the given path belongs to a source folder,
       # otherwise return NULL
       if (dir.exists(getConfig("sourcefolder")) &&
-          startsWith(normalizePath(path), normalizePath(getConfig("sourcefolder")))) {
+            startsWith(normalizePath(path), normalizePath(getConfig("sourcefolder")))) {
         return(paste0(getConfig("cachefolder"), "/fileHashCache", basename(path), ".rds"))
       } else {
         return(NULL)

--- a/R/readSource.R
+++ b/R/readSource.R
@@ -25,7 +25,7 @@
 #' the data and metadata is returned instead. The temporal and data dimensionality
 #' should match the source data. The spatial dimension should either match the source data or,
 #' if the convert argument is set to TRUE, should be on ISO code country level.
-#' @author Jan Philipp Dietrich, Anastasis Giannousakis, Lavinia Baumstark, Pascal Führlich
+#' @author Jan Philipp Dietrich, Anastasis Giannousakis, Lavinia Baumstark, Pascal Sauer
 #' @seealso \code{\link{setConfig}}, \code{\link{downloadSource}}, \code{\link{readTau}}
 #' #' @note The underlying read-functions can return a magpie object or a list of information
 #' (preferred) back to \code{readSource}. In list format the object should have the following

--- a/R/robustOrder.R
+++ b/R/robustOrder.R
@@ -13,7 +13,7 @@
 #' @param method Default is "radix", which is locale independent. The alternatives "auto" and "shell" should not be used
 #' in madrat because they are locale dependent.
 #' @seealso \code{\link[base]{order}}
-#' @author Pascal Führlich
+#' @author Pascal Sauer
 robustOrder <- function(...,
                         na.last = TRUE, # nolint: object_name_linter
                         decreasing = FALSE, method = "radix") {

--- a/R/toolstartmessage.R
+++ b/R/toolstartmessage.R
@@ -9,7 +9,7 @@
 #' next vcat executions. Currently this setting can have 4 states: NULL (nothing will be changed), 0 (reset
 #' hierarchies), "+" (increase hierarchy level by 1) and "-" (decrease hierarchy level by 1).
 #' @return A list containing diagnostic information required by \code{\link{toolendmessage}}.
-#' @author Jan Philipp Dietrich, Pascal Führlich
+#' @author Jan Philipp Dietrich, Pascal Sauer
 #' @seealso \code{\link{toolendmessage}}, \code{\link{vcat}}
 #' @importFrom utils str
 #' @examples

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.6.7**
+R package **madrat**, version **3.6.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,16 +55,16 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Führlich P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 3.6.7, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 3.6.8, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Manual{,
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
-  author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Pascal Führlich},
+  author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Pascal Sauer},
   year = {2023},
-  note = {R package version 3.6.7},
+  note = {R package version 3.6.8},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/man/compareMadratOutputs.Rd
+++ b/man/compareMadratOutputs.Rd
@@ -42,5 +42,5 @@ compareMadratOutputs("madrat", "readTau", c("paper", "historical"))
 
 }
 \author{
-Pascal Führlich
+Pascal Sauer
 }

--- a/man/downloadSource.Rd
+++ b/man/downloadSource.Rd
@@ -58,5 +58,5 @@ a <- downloadSource("Tau", subtype = "historical")
 \code{\link{setConfig}}, \code{\link{readSource}}
 }
 \author{
-Jan Philipp Dietrich, David Klein, Pascal Führlich
+Jan Philipp Dietrich, David Klein, Pascal Sauer
 }

--- a/man/fingerprint.Rd
+++ b/man/fingerprint.Rd
@@ -49,5 +49,5 @@ madrat:::fingerprint("toolGetMapping", package = "madrat")
 \code{\link{readSource}}
 }
 \author{
-Jan Philipp Dietrich, Pascal Führlich
+Jan Philipp Dietrich, Pascal Sauer
 }

--- a/man/readSource.Rd
+++ b/man/readSource.Rd
@@ -73,5 +73,5 @@ will corrupt the PUC file. Use with care.
 }
 }
 \author{
-Jan Philipp Dietrich, Anastasis Giannousakis, Lavinia Baumstark, Pascal Führlich
+Jan Philipp Dietrich, Anastasis Giannousakis, Lavinia Baumstark, Pascal Sauer
 }

--- a/man/robustOrder.Rd
+++ b/man/robustOrder.Rd
@@ -28,5 +28,5 @@ same encoding as the input although internally character vectors are converted t
 \code{\link[base]{order}}
 }
 \author{
-Pascal Führlich
+Pascal Sauer
 }

--- a/man/toolstartmessage.Rd
+++ b/man/toolstartmessage.Rd
@@ -41,5 +41,5 @@ outerFunction()
 \code{\link{toolendmessage}}, \code{\link{vcat}}
 }
 \author{
-Jan Philipp Dietrich, Pascal Führlich
+Jan Philipp Dietrich, Pascal Sauer
 }


### PR DESCRIPTION
relevant changes are in https://github.com/pik-piam/madrat/commit/bb3871c038b3e5d709269f7f705040abde51d51c
I think the reason why codelabels were sometimes not working is because the tgz was generated from an existing puc. The puc includes an renv which is used to re-run the full function in a new R session, and codelabels were not moved over to this new R session. This PR fixes that.