### PR TITLE
allow missing years in calcOutput

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '7318728'
+ValidationKey: '7342505'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.7.2
-date-released: '2023-11-13'
+version: 3.7.3
+date-released: '2023-11-24'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.7.2
-Date: 2023-11-13
+Version: 3.7.3
+Date: 2023-11-24
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = "aut"),

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -298,9 +298,10 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
     if (x$class != "magpie") stop("years argument can only be used in combination with x$class=\"magpie\"!")
     # check that years exist in provided data
     if (!all(as.integer(sub("y", "", years)) %in% getYears(x$x, as.integer = TRUE))) {
-      stop("Some years are missing in the data provided by function ", functionname, "(",
-           paste(years[!(as.integer(sub("y", "", years)) %in% getYears(x$x, as.integer = TRUE))], collapse = ", "),
-           ")!")
+      warning("Some years are missing in the data provided by function ", functionname, "(",
+              paste(years[!(as.integer(sub("y", "", years)) %in% getYears(x$x, as.integer = TRUE))],
+                    collapse = ", "), ")!")
+      years <- intersect(as.integer(sub("y", "", years)), getYears(x$x, as.integer = TRUE))
     }
     x$x <- x$x[, years, ]
     if (!is.null(x$weight)) if (nyears(x$weight) > 1) x$weight <- x$weight[, years, ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.7.2**
+R package **madrat**, version **3.7.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 3.7.2, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 3.7.3, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Pascal Sauer},
   year = {2023},
-  note = {R package version 3.7.2},
+  note = {R package version 3.7.3},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -127,7 +127,14 @@ test_that("Calculation for tau example data set works", {
   expect_equivalent(x$x, expectedResult)
   expect_message(x <- readSource("Tau", "historical"), "loading cache")
   expect_error(x <- readSource("Tau", "wtf"), "Unknown subtype")
-  expect_error(calcOutput("TauTotal", source = "historical", years = 1800), "Some years are missing")
+  expect_warning(calcOutput("TauTotal", source = "historical", years = 1800), "Some years are missing")
+
+  x <- suppressWarnings(calcOutput("TauTotal", source = "historical", years = seq(1970, 2050, 1),
+                                   round = 2, supplementary = FALSE))
+  expect_true(length(getYears(x, as.integer = TRUE)) == 38)
+  expect_true(1970 %in% getYears(x, as.integer = TRUE))
+  expect_true(2007 %in% getYears(x, as.integer = TRUE))
+  expect_false(2008 %in% getYears(x, as.integer = TRUE))
   sink()
 })
 


### PR DESCRIPTION
Addresses https://github.com/pik-piam/madrat/issues/193

When `years` passed to `calcOutput` are not in produced data, a warning is thrown instead of an error and only the requested years available in the data are returned.