### PR TITLE
allow for fingerprint() to hash full files if a .fullhash file is present in the directory

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '7342505'
+ValidationKey: '7484100'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.7.3
-date-released: '2023-11-24'
+version: 3.8.0
+date-released: '2023-12-04'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.7.3
-Date: 2023-11-24
+Version: 3.8.0
+Date: 2023-12-04
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = "aut"),

--- a/R/fingerprint.R
+++ b/R/fingerprint.R
@@ -160,8 +160,16 @@ fingerprintFiles <- function(paths) {
     }
 
     if (!is.null(files)) {
-      # use the first 300 byte of each file and the file sizes for hashing
-      files$hash <- vapply(files$path, digest, character(1), algo = getConfig("hash"), file = TRUE, length = 300)
+      # hash the first 300 bytes of each file, or the entire file if a
+      # `.fullhash` file is present in the directory
+      files$hash <- vapply(
+        files$path,
+        digest,
+        character(1),
+        algo = getConfig("hash"),
+        file = TRUE,
+        length = ifelse(file.exists(file.path(path, ".fullhash")), Inf, 300)
+      )
       files$path <- NULL
       if (!is.null(hashCacheFile)) {
         if (!dir.exists(dirname(hashCacheFile))) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.7.3**
+R package **madrat**, version **3.8.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 3.7.3, <https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2023). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 3.8.0, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Pascal Sauer},
   year = {2023},
-  note = {R package version 3.7.3},
+  note = {R package version 3.8.0},
   doi = {10.5281/zenodo.1115490},
   url = {https://github.com/pik-piam/madrat},
 }


### PR DESCRIPTION
We have a couple of sources consisting of stylised parameters across a bunch of scenarios
```
$ ls -l /p/projects/rd3mod/inputdata/sources/industry_subsectors_specific/
total 66
-rw-rw-r-- 2 pehl rdev  494 Apr 21  2022 industry_specific_FE_limits.csv
-rw-rw-r-- 1 pehl rdev 4054 Aug 19  2022 specific_FE.csv
-rw-rw-r-- 1 pehl rdev 1017 Jun 17  2022 specific_material_alpha.csv
-rw-rw-r-- 1 pehl rdev  375 Mar 20  2023 specific_material_relative_change.csv
-rw-rw-r-- 1 pehl rdev 6021 Aug 19  2022 specific_material_relative.csv
```
It is entirely possible that these parameters are modified
1. without changing the file size, if a n-digit numbers are simply replaced by other n-digit numbers, or if the changes happen to add and remove the same number of characters, and
2. without changing anything in the first 300 bytes of the files, which in the case of `industry_specific_FE_limits.csv` are consumed entirely by the comment header and part of the csv header:
   ```
   $ head -c 300 industry_specific_FE_limits.csv 
   # Thermodynamic limits on industry specific FE consumption by Silvia Madeddu
   # (see post https://mattermost.pik-potsdam.de/rd3/pl/u7eg6ed5gpr85rabznepnaoqrr
   # and https://mattermost.pik-potsdam.de/rd3/pl/g74og14a7igi8n6trjbhgcntrc).
   # GJ/t for absolute subsectors, share for relative subsectors
   subse
   ```
   and in the case of `specific_material_relative.csv` make up just of five of the 136 data lines.

-----

Analogous to [this](https://github.com/pik-piam/madrat/blob/c8f225104461c253ae9f4983ed427f0b4afcfd5f/R/fingerprint.R#L108-L109), if a file `.fullhash` is present in the directory, the entire files will be hashed, not just the first 300 bytes.