### PR TITLE
Update madrat-package.R

### DIFF
--- a/R/madrat-package.R
+++ b/R/madrat-package.R
@@ -9,5 +9,4 @@
 #' 
 #' @name madrat-package
 #' @aliases madrat-package madrat
-#' @docType package
-NULL
+"_PACKAGE"


### PR DESCRIPTION
roxygen2 7.3.0 deprecated `@docType package`, instead `"_PACKAGE"` should be documented