### PR TITLE
Add new tool function

### DIFF
--- a/R/toolGetUnitDollar.R
+++ b/R/toolGetUnitDollar.R
@@ -1,0 +1,8 @@
+toolGetUnitDollar <- function(returnOnlyBase = FALSE, inPPPP = TRUE) {
+  base <- 2017
+  if (returnOnlyBase) {
+    return(base)
+  }
+  pppOrMer <- if (inPPPP) " Int$PPP" else " US$MER"
+  paste0("constant ", base, pppOrMer)
+}


### PR DESCRIPTION
The idea here is to create a central parameter/function with which we control/set the monetary unit, throughout the magpie/remind pre-processing. 
In effect, the crucial part is the monetary unit's **base year** (our choice of currency, the $, in PPP or MER, not really being up for debate).

Ideally, this function will be called every time monetary values are converted, providing the unit in which the values are to be converted to. The conversion process itself should rely on `GDPuc::convertGDP` (since this function/package will be used for all monetary conversions, the naming should perhaps be revised...). To make the whole process as easy as possible, the proposed function, here called `toolGetUnitDollar`, would ideally return the exact string that can be passed to `GDPuc::convertGDP`'s `unit_out` argument.

Questions:

- Is this package the right place to introduce a function like this?
- Should we take this opportunity and create the framework for a more general `toolGetUnit` function?
- Where should the units be defined? In this case, the base year is defined within the tool function itself. Perhaps a special, external file should be used instead? Where all units are defined?