### PR TITLE
fix tool regex

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '61836632'
+ValidationKey: '61875180'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.11.3
-date-released: '2024-05-21'
+version: 3.11.4
+date-released: '2024-05-27'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.11.3
-Date: 2024-05-21
+Version: 3.11.4
+Date: 2024-05-27
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut", "cre")),

--- a/R/getMadratGraph.R
+++ b/R/getMadratGraph.R
@@ -52,7 +52,7 @@ getMadratGraph <- function(packages = installedMadratUniverse(), globalenv = get
   out <- as.data.frame(out, stringsAsFactors = FALSE)
 
   # extract tool calls
-  pattern <- "tool([^( ]*)\\("
+  pattern <- "\\btool([^( :]*)\\("
   matches <- stri_match_all_regex(code, pattern, omit_no_match = TRUE)
   names(matches) <- names(code)
   tmpfun <- function(x, l) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.11.3**
+R package **madrat**, version **3.11.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2024). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 3.11.3, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2024). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 3.11.4, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,8 +64,8 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Pascal Sauer},
   year = {2024},
-  note = {R package version 3.11.3},
-  doi = {10.5281/zenodo.1115490},
+  note = {R package version 3.11.4},
   url = {https://github.com/pik-piam/madrat},
+  doi = {10.5281/zenodo.1115490},
 }
 ```


### PR DESCRIPTION
Previously the regex `"tool([^( ]*)\\("` was in our R code. It matches "if (...) toolSomething(...)" as intended, but it also matched "tools::file_ext(...)", "mstools::toolSomething(...)" (substring "tools::toolSomething(" matched, which does not make sense), or "function_with_tool_anywhere(...)" (substring "tool_anywhere(" matched), frequently leading to false warnings e.g. when calling mstools tool functions via the recommended `::`. This PR fixes all of these cases.