### PR TITLE
init folder config from envvars

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '61926200'
+ValidationKey: '62025600'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.11.5
+version: 3.12.0
 date-released: '2024-06-06'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.11.5
+Version: 3.12.0
 Date: 2024-06-06
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/R/initializeConfig.R
+++ b/R/initializeConfig.R
@@ -1,7 +1,10 @@
 #' initializeConfig
 #'
 #' Checks whether configuration already has been set. If not, it will be initialized
-#' with default settings or (if available) system settings.
+#' with default settings or (if available) system settings. All madrat folders (see
+#' \code{\link{setConfig}} for documentation which folders are available) will be set
+#' to the system environment variables MADRAT_SOURCEFOLDER, MADRAT_CACHEFOLDER, etc.
+#' if they exist, NA otherwise. NA means subfolders of the mainfolder are used.
 #'
 #' @param verbose boolean deciding whether status information/updates should be shown or not
 #' @author Jan Philipp Dietrich
@@ -11,7 +14,9 @@ initializeConfig <- function(verbose = TRUE) {
   # check whether config has not been initialized yet
   # and initialize it (otherwise do nothing)
   if (is.null(getOption("madrat_cfg"))) {
-    if (verbose) message("\nInitialize madrat config with default settings..")
+    if (verbose) {
+      message("\nInitializing madrat config with default settings")
+    }
 
     cfg <- list(regionmapping        = "regionmappingH12.csv",
                 extramappings        = NULL,
@@ -19,12 +24,12 @@ initializeConfig <- function(verbose = TRUE) {
                 globalenv            = FALSE,
                 verbosity            = 1,
                 mainfolder           = getMainfolder(verbose = verbose),
-                sourcefolder         = NA,
-                cachefolder          = NA,
-                mappingfolder        = NA,
-                outputfolder         = NA,
-                pucfolder            = NA,
-                tmpfolder            = NA,
+                sourcefolder         = Sys.getenv("MADRAT_SOURCEFOLDER", unset = NA),
+                cachefolder          = Sys.getenv("MADRAT_CACHEFOLDER", unset = NA),
+                mappingfolder        = Sys.getenv("MADRAT_MAPPINGFOLDER", unset = NA),
+                outputfolder         = Sys.getenv("MADRAT_OUTPUTFOLDER", unset = NA),
+                pucfolder            = Sys.getenv("MADRAT_PUCFOLDER", unset = NA),
+                tmpfolder            = Sys.getenv("MADRAT_TMPFOLDER", unset = NA),
                 nolabels             = NULL,
                 forcecache           = FALSE,
                 ignorecache          = NULL,
@@ -33,10 +38,10 @@ initializeConfig <- function(verbose = TRUE) {
                 diagnostics          = FALSE,
                 debug                = FALSE,
                 maxLengthLogMessage = 200)
-     options(madrat_cfg = cfg) # nolint
-     if (verbose) {
+    options(madrat_cfg = cfg) # nolint
+    if (verbose) {
       message(paste(paste0("    ", names(cfg)), cfg, sep = " = ", collapse = "\n"))
       message("..done!\n")
-     }
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.11.5**
+R package **madrat**, version **3.12.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2024). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 3.11.5, <https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2024). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 3.12.0, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Pascal Sauer},
   year = {2024},
-  note = {R package version 3.11.5},
+  note = {R package version 3.12.0},
   url = {https://github.com/pik-piam/madrat},
   doi = {10.5281/zenodo.1115490},
 }

--- a/man/initializeConfig.Rd
+++ b/man/initializeConfig.Rd
@@ -11,7 +11,10 @@ initializeConfig(verbose = TRUE)
 }
 \description{
 Checks whether configuration already has been set. If not, it will be initialized
-with default settings or (if available) system settings.
+with default settings or (if available) system settings. All madrat folders (see
+\code{\link{setConfig}} for documentation which folders are available) will be set
+to the system environment variables MADRAT_SOURCEFOLDER, MADRAT_CACHEFOLDER, etc.
+if they exist, NA otherwise. NA means subfolders of the mainfolder are used.
 }
 \seealso{
 \code{\link{getMainfolder}}, \code{\link{getConfig}}, \code{\link{setConfig}}


### PR DESCRIPTION
This PR allows us to set environment variables to control which cache folder is used by madrat.