### PR TITLE
extend installedMadratUniverse() to include all packages with madrat as a dependency

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '62691330'
+ValidationKey: '62859660'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.13.3
-date-released: '2024-10-14'
+version: 3.14.0
+date-released: '2024-10-23'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.13.3
-Date: 2024-10-14
+Version: 3.14.0
+Date: 2024-10-23
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/installedMadratUniverse.R
+++ b/R/installedMadratUniverse.R
@@ -1,13 +1,14 @@
 #' installedMadratUniverse
 #'
-#' Returns a name vector of installed packages which
-#' supposedly belong to the madrat universe.
-#' They are currently derived as the union of
-#' all loaded madrat packages and all packages
-#' with a name starting with "mr" or "ms"
-#' (as the usual indicator for madrat-packages and
-#' madrat-support-packages).
+#' Returns a name vector of installed packages which supposedly belong to the
+#' madrat universe.   They are currently derived as the union of
+#' - all packages registered under `getConfig("packages")`,
+#' - all packages with a name starting with "mr" or "ms" (as the usual
+#'   indicator for madrat-packages and madrat-support-packages), and
+#' - all packages having `madrat` as either a `Depends` or `Imports`
+#'   dependency.
 #'
+#' @md
 #' @return A name vector of installed packages which supposedly belong
 #' to the madrat universe
 #' @author Jan Philipp Dietrich
@@ -19,5 +20,10 @@
 #' @export
 #'
 installedMadratUniverse <- function() {
- return(robustSort(union(getConfig("packages"), grep("^m[rs]", rownames(installed.packages()), value = TRUE))))
+  pkgs <- installed.packages()
+  robustSort(unique(c(
+    getConfig("packages"),
+    grep("^m[rs]", rownames(pkgs), value = TRUE),
+    rownames(pkgs)[  grepl("\\bmadrat\\b", pkgs[,"Depends"])
+                   | grepl("\\bmadrat\\b", pkgs[,"Imports"])])))
 }

--- a/R/installedMadratUniverse.R
+++ b/R/installedMadratUniverse.R
@@ -22,8 +22,9 @@
 installedMadratUniverse <- function() {
   pkgs <- installed.packages()
   robustSort(unique(c(
-    getConfig("packages"),
-    grep("^m[rs]", rownames(pkgs), value = TRUE),
-    rownames(pkgs)[  grepl("\\bmadrat\\b", pkgs[,"Depends"])
-                   | grepl("\\bmadrat\\b", pkgs[,"Imports"])])))
+                      getConfig("packages"),
+                      grep("^m[rs]", rownames(pkgs), value = TRUE),
+                      rownames(pkgs)[grepl("\\bmadrat\\b", pkgs[, "Depends"])
+                                     | grepl("\\bmadrat\\b",
+                                             pkgs[, "Imports"])])))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.13.3**
+R package **madrat**, version **3.14.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2024). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi: 10.5281/zenodo.1115490 (URL: https://doi.org/10.5281/zenodo.1115490), R package version 3.13.3, <URL: https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2024). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 3.14.0, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,8 +64,8 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Pascal Sauer},
   year = {2024},
-  note = {R package version 3.13.3},
-  doi = {10.5281/zenodo.1115490},
+  note = {R package version 3.14.0},
   url = {https://github.com/pik-piam/madrat},
+  doi = {10.5281/zenodo.1115490},
 }
 ```


### PR DESCRIPTION
Solves the mystery question of why `GDPuc::toolConvertGDP()` is sometimes hashed and sometimes not.