### PR TITLE
simpler call stack

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '63182967'
+ValidationKey: '63234546'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.15.3
-date-released: '2024-11-12'
+version: 3.15.4
+date-released: '2024-11-22'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.15.3
-Date: 2024-11-12
+Version: 3.15.4
+Date: 2024-11-22
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/convertTau.R
+++ b/R/convertTau.R
@@ -1,8 +1,8 @@
 #' Convert Tau
-#' 
+#'
 #' Convert landuse intensity data (tau) to data on ISO country level.
-#' 
-#' 
+#'
+#'
 #' @param x MAgPIE object containing tau values and corresponding weights xref
 #' at 0.5deg cellular level.
 #' @return Tau data and weights as MAgPIE object aggregated to country level
@@ -10,35 +10,34 @@
 #' @importFrom magclass ncells getCells<- collapseNames getCells
 
 convertTau <- function(x) {
-  
+
   "!# @monitor madrat:::sysdata$iso_cell magclass:::ncells"
   "!# @ignore  madrat:::toolAggregate"
-  
-  tau  <- x[,,"tau"]
-  xref <- x[,,"xref"]
-  
+
+  tau  <- x[, , "tau"]
+  xref <- x[, , "xref"]
+
   # clean data
   # make sure that the weight for nonexisting tau values is 10^-10
-  xref[is.na(tau) | is.nan(tau)] <- 10^-10
-  #fill gaps within tau factors with 1 (the global mean)
-  tau[ is.na(tau) | is.nan(tau)] <- 1  
-  
-  #calculate numbers on country level if they are provided on cellular level
+  xref[is.na(tau)] <- 10^-10
+  # fill gaps within tau factors with 1 (the global mean)
+  tau[is.na(tau)] <- 1
+
+  # calculate numbers on country level if they are provided on cellular level
   if (ncells(x) == 59199) {
-
     # read mapping cells -> iso countries
-    iso_cell <- sysdata$iso_cell
-    iso_cell[,2] <- getCells(x)
+    isoCell <- sysdata$iso_cell
+    isoCell[, 2] <- getCells(x)
 
-    # aggregate data        
-    tau  <- toolAggregate(tau,  rel=iso_cell, weight = collapseNames(xref))
-    xref <- toolAggregate(xref, rel=iso_cell)
+    # aggregate data
+    tau  <- toolAggregate(tau,  rel = isoCell, weight = collapseNames(xref))
+    xref <- toolAggregate(xref, rel = isoCell)
   }
-  
-  #check whether the country list agrees with the list of countries in the madrat package
-  #remove unrequired data, add missing data  
-  tau  <- toolCountryFill(tau,fill=1,TLS="IDN",HKG="CHN",SGP="CHN",BHR="QAT")
-  xref <- toolCountryFill(xref, fill=0, verbosity=2)
 
-  return(mbind(tau,xref))
-}  
+  # check whether the country list agrees with the list of countries in the madrat package
+  # remove unrequired data, add missing data
+  tau  <- toolCountryFill(tau, fill = 1, TLS = "IDN", HKG = "CHN", SGP = "CHN", BHR = "QAT")
+  xref <- toolCountryFill(xref, fill = 0, verbosity = 2)
+
+  return(mbind(tau, xref))
+}

--- a/R/readSource.R
+++ b/R/readSource.R
@@ -144,9 +144,8 @@ readSource <- function(type, subtype = NULL, subset = NULL, # nolint: cyclocomp_
     # run the actual read/correct/convert function
     # if prefix is correct or convert the locally defined x is passed, so check it exists
     stopifnot(prefix == "read" || exists("x"))
-    withr::with_dir(sourcefolder, {
-      x <- withMadratLogging(eval(parse(text = functionname)))
-    })
+    withr::local_dir(sourcefolder)
+    x <- withMadratLogging(eval(parse(text = functionname)))
     setWrapperInactive("wrapperChecks")
 
     # ensure we are always working with a list with entries "x" and "class"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.15.3**
+R package **madrat**, version **3.15.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2024). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 3.15.3, <https://github.com/pik-piam/madrat>.
+Dietrich J, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Sauer P (2024). _madrat: May All Data be Reproducible and Transparent (MADRaT)_. doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, R package version 3.15.4, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT)},
   author = {Jan Philipp Dietrich and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Pascal Sauer},
   year = {2024},
-  note = {R package version 3.15.3},
+  note = {R package version 3.15.4},
   url = {https://github.com/pik-piam/madrat},
   doi = {10.5281/zenodo.1115490},
 }


### PR DESCRIPTION
This PR simplifies the call stack if an error occurs in a read/convert function which is nicer for debugging, it's a minor refactoring. Currently we get this call stack:
```
 1. └─madrat::readSource("Tau", "paper")
 2.   └─madrat (local) .getData(type, subtype, subset, args, prefix, callString) at madrat/R/readSource.R:259:3
 3.     ├─withr::with_dir(...) at madrat/R/readSource.R:147:5
 4.     │ └─base::force(code)
 5.     ├─madrat:::withMadratLogging(eval(parse(text = functionname))) at madrat/R/readSource.R:148:7
 6.     │ └─base::withCallingHandlers(...) at madrat/R/withMadratLogging.R:36:3
 7.     ├─base::eval(parse(text = functionname)) at madrat/R/withMadratLogging.R:36:3
 8.     │ └─base::eval(parse(text = functionname))
 9.     └─madrat:::convertTau(x = x)
 ```
 and with this PR 3 and 4 are omitted:
```
 1. └─madrat::readSource("Tau", "paper")
 2.   └─madrat (local) .getData(type, subtype, subset, args, prefix, callString) at madrat/R/readSource.R:258:3
 3.     ├─madrat:::withMadratLogging(eval(parse(text = functionname))) at madrat/R/readSource.R:148:5
 4.     │ └─base::withCallingHandlers(...) at madrat/R/withMadratLogging.R:36:3
 5.     ├─base::eval(parse(text = functionname))
 6.     │ └─base::eval(parse(text = functionname))
 7.     └─madrat:::convertTau(x = x)
 ```