### PR TITLE
fix for R 4.5.0dev

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '63904030'
+ValidationKey: '63924189'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.17.0
+version: 3.17.1
 date-released: '2025-03-12'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.17.0
+Version: 3.17.1
 Date: 2025-03-12
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/R/getNonDefaultArguments.R
+++ b/R/getNonDefaultArguments.R
@@ -38,7 +38,7 @@ getNonDefaultArguments <- function(functionName, args = NULL, errorOnMismatch = 
   }
 
   commonargs <- intersect(names(defargs), names(args))
-  unmatchedArgs <- setdiff(args, args[commonargs])
+  unmatchedArgs <- args[!(args %in% args[commonargs])]
   if (errorOnMismatch && !("..." %in% names(defargs)) && length(unmatchedArgs) >= 1) {
     if (length(names(defargs)) == 0) {
       acceptedArgs <- " does not support any arguments)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.17.0**
+R package **madrat**, version **3.17.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.17.0, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.17.1, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -67,6 +67,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-03-12},
   year = {2025},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.17.0},
+  note = {Version: 3.17.1},
 }
 ```


### PR DESCRIPTION
on r-universe CI was failing to build under R 4.5.0dev: https://github.com/r-universe/pik-piam/actions/runs/13816310507/job/38650576681
I was able to reproduce this locally, `setdiff` didn't preserve names there, so I had to reformulate.