### PR TITLE
Deprecates setting the diagnostics config option to a filename.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '64663401'
+ValidationKey: '65066700'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.20.1
-date-released: '2025-04-23'
+version: 3.21.0
+date-released: '2025-07-01'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.20.1
-Date: 2025-04-23
+Version: 3.21.0
+Date: 2025-07-01
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/retrieveData.R
+++ b/R/retrieveData.R
@@ -118,7 +118,7 @@ retrieveData <- function(model, rev = 0, dev = "", cachetype = "def", puc = iden
   })
   localConfig(regionmapping = paste0(cfg$regionscode[1], ".csv"),
               outputfolder = outputfolder,
-              diagnostics = "diagnostics")
+              diagnostics = TRUE)
 
   if (length(cfg$regionscode) > 1) {
     localConfig(extramappings = paste0(cfg$regionscode[-1], ".csv"))

--- a/R/setConfig.R
+++ b/R/setConfig.R
@@ -57,7 +57,8 @@
 #' @param hash specifies the used hashing algorithm. Default is "xxhash32" and
 #' all algorithms supported by \code{\link[digest]{digest}} can be used.
 #' @param diagnostics Either FALSE (default) to avoid the creation of additional
-#' log files or a file name for additional diagnostics information (without file ending).
+#' log files or TRUE to write a log of diagnostic outputs to "diagnostics.log". Setting diagnostics
+#' to a file name is deprecated.
 #' @param debug Boolean which activates a debug mode. In debug mode all calculations will
 #' be executed with try=TRUE so that calculations do not stop even if the previous calculation failed.
 #' This can be helpful to get a full picture of errors rather than only seeing the first one. In addition
@@ -143,6 +144,11 @@ setConfig <- function(regionmapping = NULL, # nolint
   if (!is.null(enablecache)) {
     warning('Argument "enablecache" is deprecated and will be ignored, use "ignorecache" instead!')
     enablecache <- NULL
+  }
+
+  if (is.character(diagnostics)) {
+    warning("Setting diagnostics to a filename is deprecated. The log is named \"diagnostics.log\". Use a Boolean value instead.") # nolint: line_length_linter.
+    diagnostics <- TRUE
   }
 
   if (!is.null(packages)) {

--- a/R/vcat.R
+++ b/R/vcat.R
@@ -70,10 +70,9 @@ vcat <- function(verbosity, ..., level = NULL, fill = TRUE, show_prefix = TRUE, 
     }
   }
 
-  d <- getConfig("diagnostics")
-  writelog <- is.character(d)
+  writelog <- getConfig("diagnostics")
   if (writelog) {
-    logfile <- paste0(getConfig("outputfolder"), "/", d, ".log")
+    logfile <- paste0(getConfig("outputfolder"), "/diagnostics.log")
   }
   prefix <- c("", "ERROR: ", "WARNING: ", "NOTE: ", "MINOR NOTE: ")[min(verbosity, 2) + 3]
   if (prefix == "" || !show_prefix) prefix <- NULL
@@ -85,8 +84,8 @@ vcat <- function(verbosity, ..., level = NULL, fill = TRUE, show_prefix = TRUE, 
     if (verbosity == -1) {
       base::message(paste(capture.output(base::cat(c(prefix, messages),
                                                    fill = fill, sep = "",
-                                                   labels = getOption("gdt_nestinglevel")
-      )), collapse = "\n"))
+                                                   labels = getOption("gdt_nestinglevel"))),
+                          collapse = "\n"))
       if (!logOnly) {
         base::stop(..., call. = FALSE)
       }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.20.1**
+R package **madrat**, version **3.21.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.20.1, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.21.0, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein},
   doi = {10.5281/zenodo.1115490},
-  date = {2025-04-23},
+  date = {2025-07-01},
   year = {2025},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.20.1},
+  note = {Version: 3.21.0},
 }
 ```

--- a/man/setConfig.Rd
+++ b/man/setConfig.Rd
@@ -104,7 +104,8 @@ use compression. TRUE corresponds to gzip compression, and character strings "gz
 all algorithms supported by \code{\link[digest]{digest}} can be used.}
 
 \item{diagnostics}{Either FALSE (default) to avoid the creation of additional
-log files or a file name for additional diagnostics information (without file ending).}
+log files or TRUE to write a log of diagnostic outputs to "diagnostics.log". Setting diagnostics
+to a file name is deprecated.}
 
 \item{debug}{Boolean which activates a debug mode. In debug mode all calculations will
 be executed with try=TRUE so that calculations do not stop even if the previous calculation failed.


### PR DESCRIPTION
There are no known uses throughout Github repos (including pik-piam).

One disadvantage is now that we hard code the file name between `vcat` and `retrieveData`: 

https://github.com/pik-piam/madrat/blob/c6f192af5908dc77f1067b023035a2fa14d010ba/R/retrieveData.R#L185

https://github.com/pik-piam/madrat/blob/c6f192af5908dc77f1067b023035a2fa14d010ba/R/vcat.R#L75