### PR TITLE
Extend calcOutput to write statistics to status log

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '65073120'
+ValidationKey: '65298380'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '65066700'
+ValidationKey: '65073120'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.21.0
-date-released: '2025-07-03'
+version: 3.22.0
+date-released: '2025-07-10'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management
@@ -49,6 +49,11 @@ authors:
 - family-names: Klein
   given-names: David
   email: dklein@pik-potsdam.de
+  affiliation: Potsdam Institute for Climate Impact Research
+- family-names: Rein
+  given-names: Patrick
+  email: patrick.rein@pik-potsdam.de
+  orcid: https://orcid.org/0000-0001-9454-8381
   affiliation: Potsdam Institute for Climate Impact Research
 license: BSD-2-Clause
 keywords:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
 version: 3.21.0
-date-released: '2025-07-01'
+date-released: '2025-07-03'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
 Version: 3.21.0
-Date: 2025-07-01
+Date: 2025-07-03
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.21.0
-Date: 2025-07-03
+Version: 3.22.0
+Date: 2025-07-10
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,9 @@ Authors@R: c(
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research")),
     person("Ulrich", "Kreidenweis", , "kreidenweis@pik-potsdam.de", role = "aut"),
     person("David", "Klein", , "dklein@pik-potsdam.de", role = "aut",
-           comment = c(affiliation = "Potsdam Institute for Climate Impact Research"))
+           comment = c(affiliation = "Potsdam Institute for Climate Impact Research")),
+    person("Patrick", "Rein", , "patrick.rein@pik-potsdam.de", role = "aut",
+           comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0001-9454-8381"))
   )
 Description: Provides a framework which should improve reproducibility and
     transparency in data processing. It provides functionality such as

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -474,6 +474,7 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
   if (!all(vapply(statistics, is.character, FUN.VALUE = logical(1)))) {
     stop("Invalid option given for outputStatistics: ", statistics)
   }
+  statistics <- unique(statistics)
   for (nameOfStatistic in statistics) {
     statisticValue <- list()
     if (nameOfStatistic == "summary") {

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -36,8 +36,8 @@
 #' Years in the magpie object will be mapped from years to periods as indicated in `temporalmapping` by
 #' calculating the weighted average using the 'weight' column. Requires magpie object to have exactly
 #' one temporal sub-dimension.
-#' @param statisticsOutput a string or list of output statistics ("summary", "sum", or "count") that
-#' denotes which statistics should be computed on the data before aggregation. Disabled by default.
+#' @param outputStatistics a single or list of output statistics ("summary", "sum", or "count") that
+#' denote which statistics should be computed on the data before aggregation. Disabled by default.
 #' @param ... Additional settings directly forwarded to the corresponding
 #' calculation function
 #' @return magpie object with the requested output data either on country or on
@@ -109,7 +109,7 @@
 calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # nolint
                        round = NULL, signif = NULL, supplementary = FALSE,
                        append = FALSE, warnNA = TRUE, na_warning = NULL, try = FALSE, # nolint
-                       regionmapping = NULL, writeArgs = NULL, temporalmapping = NULL, 
+                       regionmapping = NULL, writeArgs = NULL, temporalmapping = NULL,
                        outputStatistics = NULL, ...) {
   argumentValues <- c(as.list(environment()), list(...))  # capture arguments for logging
 
@@ -471,7 +471,7 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
 }
 
 .statisticsOutput <- function(data, callString, statistics = list()) {
-  if (!all(sapply(statistics, is.character))) {
+  if (!all(vapply(statistics, is.character, FUN.VALUE = logical(1)))) {
     stop("Invalid option given for outputStatistics: ", statistics)
   }
   for (nameOfStatistic in statistics) {
@@ -479,21 +479,26 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
     if (nameOfStatistic == "summary") {
       statisticValue <- as.list(summary(data))
       names(statisticValue) <- list("Min." = "min", "Max." = "max",
-                                "1st Qu." = "firstQuantile", "Median" = "median",
-                                "Mean" = "mean", "3rd Qu." = "thirdQuantile")[names(statisticValue)]
+                                    "1st Qu." = "firstQuantile", "Median" = "median",
+                                    "Mean" = "mean", "3rd Qu." = "thirdQuantile")[names(statisticValue)]
     } else if (nameOfStatistic == "sum") {
       statisticValue <- sum(data)
     } else if (nameOfStatistic == "count") {
       statisticValue <- length(data)
     } else {
-      stop(paste0("Unknown statistics function ", nameOfStatistic, ". Valid options are 'summary', 'sum', and 'count'."))
+      stop(paste0("Unknown statistics function ",
+                  nameOfStatistic,
+                  ". Valid options are 'summary', 'sum', and 'count'."))
     }
 
-    vcat(1, paste0("[statistics] ", nameOfStatistic, " of ", callString, ": ", paste0(as.character(statisticValue), collapse = ", ")), show_prefix = FALSE)
+    vcat(1,
+         paste0("[statistics] ",
+                nameOfStatistic, " of ", callString, ": ",
+                paste0(as.character(statisticValue), collapse = ", ")), show_prefix = FALSE)
     putMadratMessage("status",
-                    list("statistic" = nameOfStatistic, "type" = "statistic", "data" = statisticValue),
-                    fname = callString,
-                    add = TRUE)
+                     list("statistic" = nameOfStatistic, "type" = "statistic", "data" = statisticValue),
+                     fname = callString,
+                     add = TRUE)
   }
 }
 

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -36,8 +36,9 @@
 #' Years in the magpie object will be mapped from years to periods as indicated in `temporalmapping` by
 #' calculating the weighted average using the 'weight' column. Requires magpie object to have exactly
 #' one temporal sub-dimension.
-#' @param outputStatistics a single or list of output statistics ("summary", "sum", or "count") that
-#' denote which statistics should be computed on the data before aggregation. Disabled by default.
+#' @param outputStatistics a single name of a statistic function ("summary", "sum", or "count") or a
+#' vector of such names that denote which statistics should be computed on the data before aggregation. 
+#' Disabled by default.
 #' @param ... Additional settings directly forwarded to the corresponding
 #' calculation function
 #' @return magpie object with the requested output data either on country or on
@@ -94,7 +95,7 @@
 #' in RDS format. CAUTION: Deactivating caching for a data set which should be part of a PUC file
 #' will corrupt the PUC file. Use with care.
 #' }
-#' @author Jan Philipp Dietrich
+#' @author Jan Philipp Dietrich, Patrick Rein
 #' @seealso \code{\link{setConfig}}, \code{\link{calcTauTotal}},
 #' @examples
 #' \dontrun{

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -37,7 +37,7 @@
 #' calculating the weighted average using the 'weight' column. Requires magpie object to have exactly
 #' one temporal sub-dimension.
 #' @param outputStatistics a single name of a statistic function ("summary", "sum", or "count") or a
-#' vector of such names that denote which statistics should be computed on the data before aggregation. 
+#' vector of such names that denote which statistics should be computed on the data before aggregation.
 #' Disabled by default.
 #' @param ... Additional settings directly forwarded to the corresponding
 #' calculation function

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -36,6 +36,7 @@
 #' Years in the magpie object will be mapped from years to periods as indicated in `temporalmapping` by
 #' calculating the weighted average using the 'weight' column. Requires magpie object to have exactly
 #' one temporal sub-dimension.
+#' @param statisticsOutput TODO
 #' @param ... Additional settings directly forwarded to the corresponding
 #' calculation function
 #' @return magpie object with the requested output data either on country or on
@@ -107,7 +108,8 @@
 calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # nolint
                        round = NULL, signif = NULL, supplementary = FALSE,
                        append = FALSE, warnNA = TRUE, na_warning = NULL, try = FALSE, # nolint
-                       regionmapping = NULL, writeArgs = NULL, temporalmapping = NULL, ...) {
+                       regionmapping = NULL, writeArgs = NULL, temporalmapping = NULL, 
+                       outputStatistics = NULL, ...) {
   argumentValues <- c(as.list(environment()), list(...))  # capture arguments for logging
 
   setWrapperActive("calcOutput")
@@ -310,9 +312,11 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
     write(cacheFileName, file = "pucFiles", append = TRUE)
   }
 
-  mstools::toolSummaryStatisticsMessage(x$x,
-                                        "summary",
-                                        functionname = functionname)
+  if (!is.null(outputStatistics)) {
+    mstools::toolStatisticsOutput(x$x,
+                                   callString,
+                                   outputStatistics)
+  }
 
   if (!is.null(years)) {
     if (x$class != "magpie") stop("years argument can only be used in combination with x$class=\"magpie\"!")

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -310,6 +310,9 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
     write(cacheFileName, file = "pucFiles", append = TRUE)
   }
 
+  mstools::toolSummaryStatisticsMessage(x$x,
+                                        "summary",
+                                        functionname = functionname)
 
   if (!is.null(years)) {
     if (x$class != "magpie") stop("years argument can only be used in combination with x$class=\"magpie\"!")

--- a/R/putMadratMessage.R
+++ b/R/putMadratMessage.R
@@ -26,8 +26,8 @@
 
 putMadratMessage <- function(name, value, fname = -1, add = FALSE) {
   if (missing(name)) name <- NULL
-  inputIsListOfNamesAndValues <- is.null(name) && is.list(value) && !is.null(names(value))
-  if (inputIsListOfNamesAndValues) {
+  isNestedInput <- is.null(name) && is.list(value) && !is.null(names(value))
+  if (isNestedInput) {
     for (n in names(value)) {
       for (f in names(value[[n]])) {
         putMadratMessage(name = n, value = value[[n]][[f]], fname = f, add = add)

--- a/R/putMadratMessage.R
+++ b/R/putMadratMessage.R
@@ -26,14 +26,15 @@
 
 putMadratMessage <- function(name, value, fname = -1, add = FALSE) {
   if (missing(name)) name <- NULL
-  if (is.null(name) && is.list(value) && !is.null(names(value))) {
+  inputIsListOfNamesAndValues <- is.null(name) && is.list(value) && !is.null(names(value))
+  if (inputIsListOfNamesAndValues) {
     for (n in names(value)) {
       for (f in names(value[[n]])) {
         putMadratMessage(name = n, value = value[[n]][[f]], fname = f, add = add)
       }
     }
   } else {
-    if (is.numeric(fname)) fname <- as.character(sys.call(fname))[1]
+    if (is.numeric(fname)) fname <- as.character(sys.call(fname)[1])
     madratMessage <- getOption("madratMessage")
     if (is.null(name)) name <- names(madratMessage)
     for (n in name) {

--- a/R/putMadratMessage.R
+++ b/R/putMadratMessage.R
@@ -37,7 +37,7 @@ putMadratMessage <- function(name, value, fname = -1, add = FALSE) {
     madratMessage <- getOption("madratMessage")
     if (is.null(name)) name <- names(madratMessage)
     for (n in name) {
-      madratMessage[[name]][[fname]] <- if (add) c(madratMessage[[name]][[fname]], value) else value
+      madratMessage[[name]][[fname]] <- if (add) c(madratMessage[[name]][[fname]], list(value)) else value
     }
     options(madratMessage = madratMessage) # nolint: undesirable_function_linter.
   }

--- a/R/putMadratMessage.R
+++ b/R/putMadratMessage.R
@@ -34,7 +34,7 @@ putMadratMessage <- function(name, value, fname = -1, add = FALSE) {
       }
     }
   } else {
-    if (is.numeric(fname)) fname <- as.character(sys.call(fname)[1])
+    if (is.numeric(fname)) fname <- as.character(sys.call(fname))[1]
     madratMessage <- getOption("madratMessage")
     if (is.null(name)) name <- names(madratMessage)
     for (n in name) {

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein},
   doi = {10.5281/zenodo.1115490},
-  date = {2025-07-01},
+  date = {2025-07-03},
   year = {2025},
   url = {https://github.com/pik-piam/madrat},
   note = {Version: 3.21.0},

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.21.0**
+R package **madrat**, version **3.22.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,18 +55,18 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.21.0, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Rein P (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.22.0, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
-  author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein},
+  author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2025-07-03},
+  date = {2025-07-10},
   year = {2025},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.21.0},
+  note = {Version: 3.22.0},
 }
 ```

--- a/man/calcOutput.Rd
+++ b/man/calcOutput.Rd
@@ -19,6 +19,7 @@ calcOutput(
   regionmapping = NULL,
   writeArgs = NULL,
   temporalmapping = NULL,
+  outputStatistics = NULL,
   ...
 )
 }
@@ -68,6 +69,9 @@ A data frame consisting of the columns 'period', 'year' and 'weight'.
 Years in the magpie object will be mapped from years to periods as indicated in \code{temporalmapping} by
 calculating the weighted average using the 'weight' column. Requires magpie object to have exactly
 one temporal sub-dimension.}
+
+\item{outputStatistics}{a single or list of output statistics ("summary", "sum", or "count") that
+denote which statistics should be computed on the data before aggregation. Disabled by default.}
 
 \item{...}{Additional settings directly forwarded to the corresponding
 calculation function}

--- a/man/calcOutput.Rd
+++ b/man/calcOutput.Rd
@@ -70,8 +70,9 @@ Years in the magpie object will be mapped from years to periods as indicated in 
 calculating the weighted average using the 'weight' column. Requires magpie object to have exactly
 one temporal sub-dimension.}
 
-\item{outputStatistics}{a single or list of output statistics ("summary", "sum", or "count") that
-denote which statistics should be computed on the data before aggregation. Disabled by default.}
+\item{outputStatistics}{a single name of a statistic function ("summary", "sum", or "count") or a
+vector of such names that denote which statistics should be computed on the data before aggregation.
+Disabled by default.}
 
 \item{...}{Additional settings directly forwarded to the corresponding
 calculation function}
@@ -147,5 +148,5 @@ a <- calcOutput(type = "TauTotal")
 \code{\link{setConfig}}, \code{\link{calcTauTotal}},
 }
 \author{
-Jan Philipp Dietrich
+Jan Philipp Dietrich, Patrick Rein
 }

--- a/man/madrat-package.Rd
+++ b/man/madrat-package.Rd
@@ -37,6 +37,7 @@ Authors:
   \item Debbora Leip \email{leip@pik-potsdam.de} (Potsdam Institute for Climate Impact Research)
   \item Ulrich Kreidenweis \email{kreidenweis@pik-potsdam.de}
   \item David Klein \email{dklein@pik-potsdam.de} (Potsdam Institute for Climate Impact Research)
+  \item Patrick Rein \email{patrick.rein@pik-potsdam.de} (\href{https://orcid.org/0000-0001-9454-8381}{ORCID}) (Potsdam Institute for Climate Impact Research)
 }
 
 }

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -691,7 +691,7 @@ test_that("Temporal aggregation works", {
 test_that("calcOutput computes statistics output", {
   localConfig(verbosity = 0, .verbose = FALSE)
   calcTest1 <- function() {
-    return(list(x = toolCountryFill(new.magpie(c("DEU", "FRA", "JPN", "GHA", "MUS"), c(1994, 1995), , c(5L, 3L)), 1L),
+    return(list(x = toolCountryFill(new.magpie(c("DEU", "FRA", "JPN", "GHA", "MUS"), c(1994, 1995), , c(5, 3)), 1),
                 weight = NULL,
                 unit = "1",
                 description = "dummy test data"))
@@ -755,7 +755,7 @@ test_that("calcOutput error handling", {
                "Unknown statistics function fantasyStatistic")
 
   # Invalid type
-  expect_error(calcOutput("Test1", outputStatistics = 1))
-  expect_error(calcOutput("Test1", outputStatistics = TRUE))
+  expect_error(calcOutput("Test1", outputStatistics = 1), "Invalid option given for outputStatistics")
+  expect_error(calcOutput("Test1", outputStatistics = TRUE), "Invalid option given for outputStatistics")
 
 })

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -699,11 +699,11 @@ test_that("calcOutput computes statistics output", {
   globalassign("calcTest1")
 
   expectStatusMessage <- function(calcOutputResult, expectedMessage) {
-    result <- calcOutputResult
+    force(calcOutputResult)
     expect_equal(
-      !!unname(getMadratMessage("status"))[[1]],
-      !!expectedMessage,
-      tolerance=0.00001)
+                 !!unname(getMadratMessage("status"))[[1]],
+                 !!expectedMessage,
+                 tolerance = 0.00001)
     resetMadratMessages("status")
   }
 
@@ -711,23 +711,27 @@ test_that("calcOutput computes statistics output", {
 
   # Disabled by default
   expectStatusMessage(
-    calcOutput("Test1"),
-    NULL)
+                      calcOutput("Test1"),
+                      NULL)
 
   # Single statistics on unaggregated data
   expectStatusMessage(
-    calcOutput("Test1", outputStatistics = "count"),
-    list(list(statistic = "count", type = "statistic", data = 498L)))
+                      calcOutput("Test1", outputStatistics = "count"),
+                      list(list(statistic = "count", type = "statistic", data = 498L)))
 
   # Multiple statistics
   expectStatusMessage(
-    calcOutput("Test1", outputStatistics = c("count", "sum", "summary")),
-    list(
-      list(statistic = "count", type = "statistic", data = 498L),
-      list(statistic = "sum", type = "statistic", data = 528L),
-      list(statistic = "summary", type = "statistic", data = list(
-        min = 1.00, firstQuantile = 1.00, median = 1.00, mean = 1.060241, thirdQuantile = 1.00, max = 5.00
-      ))))
+                      calcOutput("Test1", outputStatistics = c("count", "sum", "summary")),
+                      list(
+                           list(statistic = "count", type = "statistic", data = 498L),
+                           list(statistic = "sum", type = "statistic", data = 528L),
+                           list(statistic = "summary", type = "statistic",
+                                data = list(min = 1.00,
+                                            firstQuantile = 1.00,
+                                            median = 1.00,
+                                            mean = 1.060241,
+                                            thirdQuantile = 1.00,
+                                            max = 5.00))))
 })
 
 test_that("calcOutput error handling", {
@@ -741,15 +745,12 @@ test_that("calcOutput error handling", {
   globalassign("calcTest1")
 
   # Unknown statistic
-  expect_error(
-    calcOutput("Test1", outputStatistics = "fantasyStatistic"),
-    "Unknown statistics function fantasyStatistic")
+  expect_error(calcOutput("Test1",
+                          outputStatistics = "fantasyStatistic"),
+               "Unknown statistics function fantasyStatistic")
 
   # Invalid type
-  expect_error(
-    calcOutput("Test1", outputStatistics = 1))
-  expect_error(
-    calcOutput("Test1", outputStatistics = TRUE))
-
+  expect_error(calcOutput("Test1", outputStatistics = 1))
+  expect_error(calcOutput("Test1", outputStatistics = TRUE))
 
 })

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -732,6 +732,11 @@ test_that("calcOutput computes statistics output", {
                                             mean = 1.060241,
                                             thirdQuantile = 1.00,
                                             max = 5.00))))
+
+  # Repeated statistics are ignored
+  expectStatusMessage(
+                      calcOutput("Test1", outputStatistics = c("count", "count")),
+                      list(list(statistic = "count", type = "statistic", data = 498L)))
 })
 
 test_that("calcOutput error handling", {

--- a/tests/testthat/test-getputMadratMessage.R
+++ b/tests/testthat/test-getputMadratMessage.R
@@ -6,9 +6,9 @@ test_that("getMadratMessage and putMadratMessage work", {
   expect_silent(putMadratMessage("test", "This is a test", fname = "example"))
   expect_silent(putMadratMessage("test", "This is a toast", fname = "readTau"))
   expect_silent(putMadratMessage("test", list(a = 1, b = list(2, 3)), fname = "example2"))
-  expect_equal(getOption("madratMessage"), list(test = list(example = "This is a test",
-                                                            readTau = "This is a toast",
-                                                            example2 = list(a = 1, b = list(2, 3)))))
+  expect_identical(getOption("madratMessage"), list(test = list(example = "This is a test",
+                                                                readTau = "This is a toast",
+                                                                example2 = list(a = 1, b = list(2, 3)))))
 
   # Empty messages
   expect_silent(resetMadratMessages())

--- a/tests/testthat/test-getputMadratMessage.R
+++ b/tests/testthat/test-getputMadratMessage.R
@@ -7,14 +7,14 @@ test_that("getMadratMessage and putMadratMessage work", {
   expect_silent(putMadratMessage("test", "This is a toast", fname = "readTau"))
   expect_silent(putMadratMessage("test", list(a = 1, b = list(2, 3)), fname = "example2"))
   expect_equal(getOption("madratMessage"), list(test = list(example = "This is a test",
-                                                                readTau = "This is a toast",
-                                                                example2 = list(a = 1, b = list(2, 3)))))
-  
+                                                            readTau = "This is a toast",
+                                                            example2 = list(a = 1, b = list(2, 3)))))
+
   # Empty messages
   expect_silent(resetMadratMessages())
   expect_null(getMadratMessage())
 
-  # getMadratMessage also returns messages from called functions 
+  # getMadratMessage also returns messages from called functions
   expect_silent(putMadratMessage("test2", "another test", fname = "convertTau"))
   expect_identical(getMadratMessage(fname = "calcTauTotal"), list(test2 = list(convertTau = "another test")))
   expect_identical(getMadratMessage(fname = "readTau"), list(test2 = list(convertTau = "another test")))

--- a/tests/testthat/test-getputMadratMessage.R
+++ b/tests/testthat/test-getputMadratMessage.R
@@ -1,18 +1,27 @@
 test_that("getMadratMessage and putMadratMessage work", {
   localConfig(globalenv = FALSE, .verbose = FALSE)
   expect_silent(resetMadratMessages())
+
+  # Basic text and list messages
   expect_silent(putMadratMessage("test", "This is a test", fname = "example"))
   expect_silent(putMadratMessage("test", "This is a toast", fname = "readTau"))
-  expect_identical(getOption("madratMessage"), list(test = list(example = "This is a test",
-                                                                readTau = "This is a toast")))
-  expect_identical(getMadratMessage("test", fname = "calcTauTotal"), list(readTau = "This is a toast"))
+  expect_silent(putMadratMessage("test", list(a = 1, b = list(2, 3)), fname = "example2"))
+  expect_equal(getOption("madratMessage"), list(test = list(example = "This is a test",
+                                                                readTau = "This is a toast",
+                                                                example2 = list(a = 1, b = list(2, 3)))))
+  
+  # Empty messages
   expect_silent(resetMadratMessages())
   expect_null(getMadratMessage())
+
+  # getMadratMessage also returns messages from called functions 
   expect_silent(putMadratMessage("test2", "another test", fname = "convertTau"))
   expect_identical(getMadratMessage(fname = "calcTauTotal"), list(test2 = list(convertTau = "another test")))
   expect_identical(getMadratMessage(fname = "readTau"), list(test2 = list(convertTau = "another test")))
   expect_identical(getMadratMessage(fname = "convertTau"), list(test2 = list(convertTau = "another test")))
   resetMadratMessages()
+
+  # support for determining fname at different stack depths
   test <- function() {
     putMadratMessage("level", "level 1")
     .tmp <- function() {
@@ -22,9 +31,9 @@ test_that("getMadratMessage and putMadratMessage work", {
     .tmp()
   }
   test()
-  expect_identical(getMadratMessage(), list(level = list(test = c("level 1", "level 1 again"), .tmp = "level 2")))
+  expect_identical(getMadratMessage(), list(level = list(test = list("level 1", "level 1 again"), .tmp = "level 2")))
   expect_silent(resetMadratMessages(fname = ".tmp"))
-  expect_identical(getMadratMessage(), list(level = list(test = c("level 1", "level 1 again"))))
+  expect_identical(getMadratMessage(), list(level = list(test = list("level 1", "level 1 again"))))
   expect_silent(resetMadratMessages("level"))
   expect_null(getMadratMessage())
 })


### PR DESCRIPTION
This PR adds a feature to `calcOutput` that allows users to write statistics on the unaggregated data to the status log. These statistics are supposed to be used to check whether there were changes in the input data between two runs of a pipeline.

Depends on https://github.com/pik-piam/mstools/pull/4

This PR includes:
 - Adds a parameter to `calcOutput` and the code to actually calculate and write the statistic
 - Adapts `putMadratMessage` to support structured madrat messages
 - Adds tests for the new `calcOutput` feature
 - Adapts existing `putMadratMessage` tests to also test for structured madrat messages

Open questions:

- [x] Should `.statisticsOutput` be inlined into calcOutput, because of the fingerprinting?
- [x] What about input data formats other than `magclass`?