### PR TITLE
Fix partialArgumentMatch of output to outputStatistics

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '65298380'
+ValidationKey: '65321880'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.22.0
-date-released: '2025-07-10'
+version: 3.22.1
+date-released: '2025-07-11'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.22.0
-Date: 2025-07-10
+Version: 3.22.1
+Date: 2025-07-11
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -36,11 +36,11 @@
 #' Years in the magpie object will be mapped from years to periods as indicated in `temporalmapping` by
 #' calculating the weighted average using the 'weight' column. Requires magpie object to have exactly
 #' one temporal sub-dimension.
+#' @param ... Additional settings directly forwarded to the corresponding
+#' calculation function
 #' @param outputStatistics a single name of a statistic function ("summary", "sum", or "count") or a
 #' vector of such names that denote which statistics should be computed on the data before aggregation.
 #' Disabled by default.
-#' @param ... Additional settings directly forwarded to the corresponding
-#' calculation function
 #' @return magpie object with the requested output data either on country or on
 #' regional level depending on the choice of argument "aggregate" or a list of information
 #' if supplementary is set to TRUE.
@@ -111,7 +111,7 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
                        round = NULL, signif = NULL, supplementary = FALSE,
                        append = FALSE, warnNA = TRUE, na_warning = NULL, try = FALSE, # nolint
                        regionmapping = NULL, writeArgs = NULL, temporalmapping = NULL,
-                       outputStatistics = NULL, ...) {
+                       ..., outputStatistics = NULL) {
   argumentValues <- c(as.list(environment()), list(...))  # capture arguments for logging
 
   setWrapperActive("calcOutput")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.22.0**
+R package **madrat**, version **3.22.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Rein P (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.22.0, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Rein P (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.22.1, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2025-07-10},
+  date = {2025-07-11},
   year = {2025},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.22.0},
+  note = {Version: 3.22.1},
 }
 ```

--- a/man/calcOutput.Rd
+++ b/man/calcOutput.Rd
@@ -19,8 +19,8 @@ calcOutput(
   regionmapping = NULL,
   writeArgs = NULL,
   temporalmapping = NULL,
-  outputStatistics = NULL,
-  ...
+  ...,
+  outputStatistics = NULL
 )
 }
 \arguments{
@@ -70,12 +70,12 @@ Years in the magpie object will be mapped from years to periods as indicated in 
 calculating the weighted average using the 'weight' column. Requires magpie object to have exactly
 one temporal sub-dimension.}
 
+\item{...}{Additional settings directly forwarded to the corresponding
+calculation function}
+
 \item{outputStatistics}{a single name of a statistic function ("summary", "sum", or "count") or a
 vector of such names that denote which statistics should be computed on the data before aggregation.
 Disabled by default.}
-
-\item{...}{Additional settings directly forwarded to the corresponding
-calculation function}
 }
 \value{
 magpie object with the requested output data either on country or on

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -741,7 +741,7 @@ test_that("calcOutput computes statistics output", {
 
 test_that("calcOutput error handling", {
   localConfig(verbosity = 0, .verbose = FALSE)
-  calcTest1 <- function() {
+  calcTest1 <- function(output = NULL) {
     return(list(x = toolCountryFill(new.magpie(c("DEU", "FRA", "JPN", "GHA", "MUS"), c(1994, 1995), , c(5L, 3L)), 1L),
                 weight = NULL,
                 unit = "1",
@@ -757,5 +757,8 @@ test_that("calcOutput error handling", {
   # Invalid type
   expect_error(calcOutput("Test1", outputStatistics = 1), "Invalid option given for outputStatistics")
   expect_error(calcOutput("Test1", outputStatistics = TRUE), "Invalid option given for outputStatistics")
+
+  # No partial argument match occurs
+  calcOutput("Test1", output = 1)
 
 })


### PR DESCRIPTION
This only moves `outputStatistics` after `...` and adds a trivial test to ensure we notice a regression.