### PR TITLE
Prevent accidental setting of positional arguments in setConfig 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '65321880'
+ValidationKey: '65380824'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.22.1
-date-released: '2025-07-11'
+version: 3.22.2
+date-released: '2025-07-23'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.22.1
-Date: 2025-07-11
+Version: 3.22.2
+Date: 2025-07-23
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/setConfig.R
+++ b/R/setConfig.R
@@ -89,7 +89,7 @@
 #' @importFrom utils installed.packages
 #' @importFrom withr local_options
 #' @export
-setConfig <- function(...,
+setConfig <- function(..., # nolint: cyclocomp_linter.
                       regionmapping = NULL, # nolint
                       extramappings = NULL,
                       packages = NULL,

--- a/R/setConfig.R
+++ b/R/setConfig.R
@@ -90,7 +90,7 @@
 #' @importFrom withr local_options
 #' @export
 setConfig <- function(..., # nolint: cyclocomp_linter.
-                      regionmapping = NULL, # nolint
+                      regionmapping = NULL,
                       extramappings = NULL,
                       packages = NULL,
                       globalenv = NULL,

--- a/R/setConfig.R
+++ b/R/setConfig.R
@@ -89,7 +89,8 @@
 #' @importFrom utils installed.packages
 #' @importFrom withr local_options
 #' @export
-setConfig <- function(regionmapping = NULL, # nolint
+setConfig <- function(...,
+                      regionmapping = NULL, # nolint
                       extramappings = NULL,
                       packages = NULL,
                       globalenv = NULL,
@@ -114,6 +115,10 @@ setConfig <- function(regionmapping = NULL, # nolint
                       .cfgchecks = TRUE,
                       .verbose = TRUE,
                       .local = FALSE) {
+
+  if (...length() > 0) {
+    stop("setConfig does not accept positional arguments. Please use the form setConfig(configField = configValue).")
+  }
 
   if (isWrapperActive("wrapperChecks")) {
     for (w in c("downloadSource", "readSource", "calcOutput", "retrieveData")) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.22.1**
+R package **madrat**, version **3.22.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Rein P (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.22.1, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Rein P (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.22.2, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2025-07-11},
+  date = {2025-07-23},
   year = {2025},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.22.1},
+  note = {Version: 3.22.2},
 }
 ```

--- a/man/setConfig.Rd
+++ b/man/setConfig.Rd
@@ -6,6 +6,7 @@
 \title{setConfig}
 \usage{
 setConfig(
+  ...,
   regionmapping = NULL,
   extramappings = NULL,
   packages = NULL,
@@ -36,6 +37,8 @@ setConfig(
 localConfig(...)
 }
 \arguments{
+\item{...}{Arguments forwarded to setConfig}
+
 \item{regionmapping}{The name of the csv file containing the region mapping
 that should be used for aggregation (e.g. "regionmappingREMIND.csv").}
 
@@ -128,8 +131,6 @@ in regular cases)}
 
 \item{.local}{boolean deciding whether options are only changed until the end of the current function execution
 OR environment for which the options should get changed.}
-
-\item{...}{Arguments forwarded to setConfig}
 }
 \description{
 This function manipulates the current madrat configuration.

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -58,3 +58,10 @@ test_that("addMapping works", {
   expect_error(addMapping("test.blablub", map), "Unsupported filetype")
   expect_error(addMapping("blablub.csv", TRUE), "Cannot handle this mapping format")
 })
+
+test_that("setting via positional arguments is prevented", {
+  # Passing positional arguments leads to accidential modifications
+  # of config fields
+  expect_error(setConfig("mainfolder", "data"), "setConfig does not accept positional arguments")
+  expect_error(localConfig("mainfolder", "data"), "setConfig does not accept positional arguments")
+})


### PR DESCRIPTION
This PR changes `setConfig` so that when using a positional parameter instead of a named parameter no config fields will change.