### PR TITLE
allow skipping clean_magpie in calcOutput

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '65380824'
+ValidationKey: '65569000'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.22.2
-date-released: '2025-07-23'
+version: 3.23.0
+date-released: '2025-07-31'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.22.2
+Version: 3.22.2.9001
 Date: 2025-07-23
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.22.2.9001
-Date: 2025-07-23
+Version: 3.23.0
+Date: 2025-07-31
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -94,6 +94,7 @@
 #' the corresponding file sizes are huge. Or if the caching for the given data type does not support storage
 #' in RDS format. CAUTION: Deactivating caching for a data set which should be part of a PUC file
 #' will corrupt the PUC file. Use with care.
+#' \item \bold{clean_magpie} (optional) boolean, if set to FALSE magclass::clean_magpie will not be run on the result
 #' }
 #' @author Jan Philipp Dietrich, Patrick Rein
 #' @seealso \code{\link{setConfig}}, \code{\link{calcTauTotal}},

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -427,7 +427,9 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
 
   if (x$class == "magpie") {
     getComment(x$x) <- extendedComment
-    x$x <- clean_magpie(x$x)
+    if (!isFALSE(x$clean_magpie)) {
+      x$x <- clean_magpie(x$x)
+    }
   } else {
     attr(x$x, "comment") <- extendedComment
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.22.2**
+R package **madrat**, version **3.23.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Rein P (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.22.2, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Kreidenweis U, Klein D, Rein P (2025). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.23.0, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2025-07-23},
+  date = {2025-07-31},
   year = {2025},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.22.2},
+  note = {Version: 3.23.0},
 }
 ```

--- a/man/calcOutput.Rd
+++ b/man/calcOutput.Rd
@@ -136,6 +136,7 @@ or not. Default setting is TRUE. This can be for instance useful, if the calcula
 the corresponding file sizes are huge. Or if the caching for the given data type does not support storage
 in RDS format. CAUTION: Deactivating caching for a data set which should be part of a PUC file
 will corrupt the PUC file. Use with care.
+\item \bold{clean_magpie} (optional) boolean, if set to FALSE magclass::clean_magpie will not be run on the result
 }
 }
 \examples{


### PR DESCRIPTION
- **allow skipping clean_magpie in calcOutput**
clean_magpie would remove the id subdim from regional data, but in mrdownscale the id subdim is expected
