### PR TITLE
Fix positional argument error for setConfig args

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '69004691'
+ValidationKey: '69062204'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.36.1
-date-released: '2026-03-19'
+version: 3.36.2
+date-released: '2026-03-30'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.36.1
-Date: 2026-03-19
+Version: 3.36.2
+Date: 2026-03-30
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/setConfig.R
+++ b/R/setConfig.R
@@ -116,8 +116,13 @@ setConfig <- function(..., # nolint: cyclocomp_linter.
                       .verbose = TRUE,
                       .local = FALSE) {
 
-  if (...length() > 0) {
-    stop("setConfig does not accept positional arguments. Please use the form setConfig(configField = configValue).")
+  dots <- list(...)
+  if (length(dots) > 0) {
+    if (is.null(names(dots)) || "" %in% names(dots)) {
+      stop("setConfig does not accept positional arguments. Please use the form setConfig(configField = configValue).")
+    } else {
+      stop(names(dots), " are not valid config fields (see documentation of setConfig for list of valid parameters).")
+    }
   }
 
   if (isWrapperActive("wrapperChecks")) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.36.1**
+R package **madrat**, version **3.36.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.36.1, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.36.2, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Michael Crawford and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2026-03-19},
+  date = {2026-03-30},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.36.1},
+  note = {Version: 3.36.2},
 }
 ```

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -65,6 +65,6 @@ test_that("setting via positional arguments is prevented", {
   expect_error(setConfig("mainfolder", "data"), "setConfig does not accept positional arguments")
   expect_error(localConfig("mainfolder", "data"), "setConfig does not accept positional arguments")
 
-  expect_error(setConfig(somefolder="mainfolder"), "somefolder are not valid config fields")
-  expect_error(localConfig(somefolder="mainfolder"), "somefolder are not valid config fields")
+  expect_error(setConfig(somefolder = "mainfolder"), "somefolder are not valid config fields")
+  expect_error(localConfig(somefolder = "mainfolder"), "somefolder are not valid config fields")
 })

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -64,4 +64,7 @@ test_that("setting via positional arguments is prevented", {
   # of config fields
   expect_error(setConfig("mainfolder", "data"), "setConfig does not accept positional arguments")
   expect_error(localConfig("mainfolder", "data"), "setConfig does not accept positional arguments")
+
+  expect_error(setConfig(somefolder="mainfolder"), "somefolder are not valid config fields")
+  expect_error(localConfig(somefolder="mainfolder"), "somefolder are not valid config fields")
 })


### PR DESCRIPTION
The current behavior often yields unhelpful error messages (at least for me), as it treats wrongly named arguments as illegal positional arguments.