### PR TITLE
Improve findBottlenecks to handle multiple retrieveData calls

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '69315220'
+ValidationKey: '69523100'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -21,14 +21,14 @@ jobs:
     container:
       image: ghcr.io/pik-piam/ci-image:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install
         shell: Rscript {0}
         run: |
           options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
                             CRAN = Sys.getenv('RSPM')))
-          pak::pak(".")
+          pak::pak(".", dependencies = 'all')
           pak::pkg_install("tidyverse/tidytemplate")
 
       - name: Build site
@@ -37,7 +37,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           clean: false
           branch: gh-pages

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.36.4
-date-released: '2026-06-01'
+version: 3.37.0
+date-released: '2026-06-26'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.36.4
-Date: 2026-06-01
+Version: 3.37.0
+Date: 2026-06-26
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/findBottlenecks.R
+++ b/R/findBottlenecks.R
@@ -21,6 +21,7 @@ findBottlenecks <- function(file, unit = "min", cumulative = TRUE) {
   }
 
   f <- .mergeSplitLogLines(f)
+  # Only use the ends of blocks, nesting information is included in the prefix of each line.
   f <- grep("in [0-9.]* seconds", f, value = TRUE)
 
   x <- data.frame(level = nchar(gsub("^(~*).*$", "\\1", f)))

--- a/R/findBottlenecks.R
+++ b/R/findBottlenecks.R
@@ -6,9 +6,10 @@
 #' @param file path to a log file or content of a log as character vector
 #' @param cumulative boolean deciding whether calls to the same function should be aggregated or not
 #' @param unit unit for runtime information, either "s" (seconds), "min" (minutes) or "h" (hours)
-#' @return A data.frame sorted by net runtime showing for the different data processing functions their
-#' total runtime "time" (including the execution of all sub-functions) and net runtime "net" (excluding
-#' the runtime of sub-functions) and their share of total runtime.
+#' @return A named list with one entry per retrieveData call found in the log. The names are the
+#' retrieveData types and each entry is a data.frame sorted by net runtime showing for the different
+#' data processing functions their total runtime "time" (including the execution of all sub-functions)
+#' and net runtime "net" (excluding the runtime of sub-functions) and their share of total runtime.
 #' @author Jan Philipp Dietrich
 #' @family analysis
 #' @export
@@ -35,6 +36,30 @@ findBottlenecks <- function(file, unit = "min", cumulative = TRUE) {
   x$level[x$class == "retrieve"] <- -1
   x$type <- gsub("([\"= ]|type)", "", gsub("^[^(]*\\(([^,)]*)[),].*$", "\\1", f))
   x$"time[s]" <- as.numeric(gsub("^.* in ([0-9.]*) seconds.*$", "\\1", f)) # nolint
+
+  # Each retrieveData line marks the end of one retrieveData block. Split the log into one
+  # segment per retrieveData call and analyze each independently.
+  retrieveIdx <- which(x$class == "retrieve")
+  if (length(retrieveIdx) == 0) {
+    warning("No retrieveData call could be detected in the log!")
+    return(stats::setNames(list(), character(0)))
+  }
+  if (max(retrieveIdx) < nrow(x)) {
+    warning("Log lines after the last retrieveData call were ignored (incomplete block).")
+  }
+
+  starts <- c(1, utils::head(retrieveIdx, -1) + 1)
+  out <- list()
+  for (k in seq_along(retrieveIdx)) {
+    segment <- x[starts[k]:retrieveIdx[k], , drop = FALSE]
+    type <- x$type[retrieveIdx[k]]
+    out[[type]] <- .analyzeBottlenecks(segment, type, unit, cumulative)
+  }
+  return(out)
+}
+
+.analyzeBottlenecks <- function(x, type, unit, cumulative) {
+  rownames(x) <- NULL
   x$"net[s]" <- NA # nolint
   runtime <- rep(0, max(x$level) + 3)
   for (i in seq_len(nrow(x))) {
@@ -70,7 +95,7 @@ findBottlenecks <- function(file, unit = "min", cumulative = TRUE) {
   th   <- floor(totalruntime / 3600)
   tmin <- floor((totalruntime - th * 3600) / 60)
   ts   <- floor(totalruntime - th * 3600 - tmin * 60)
-  message("Total runtime: ", th, " hours ", tmin, " minutes ", ts, " seconds")
+  message("Total runtime (", type, "): ", th, " hours ", tmin, " minutes ", ts, " seconds")
   x$"time[%]" <- round(x$"time[s]" / totalruntime * 100, 2) # nolint
   x$"net[%]" <- round(x$"net[s]" / totalruntime * 100, 2) # nolint
   x <- x[robustOrder(x$"net[s]", decreasing = TRUE), ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.36.4**
+R package **madrat**, version **3.37.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.36.4, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.37.0, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Michael Crawford and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2026-06-01},
+  date = {2026-06-26},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.36.4},
+  note = {Version: 3.37.0},
 }
 ```

--- a/man/findBottlenecks.Rd
+++ b/man/findBottlenecks.Rd
@@ -14,9 +14,10 @@ findBottlenecks(file, unit = "min", cumulative = TRUE)
 \item{cumulative}{boolean deciding whether calls to the same function should be aggregated or not}
 }
 \value{
-A data.frame sorted by net runtime showing for the different data processing functions their
-total runtime "time" (including the execution of all sub-functions) and net runtime "net" (excluding
-the runtime of sub-functions) and their share of total runtime.
+A named list with one entry per retrieveData call found in the log. The names are the
+retrieveData types and each entry is a data.frame sorted by net runtime showing for the different
+data processing functions their total runtime "time" (including the execution of all sub-functions)
+and net runtime "net" (excluding the runtime of sub-functions) and their share of total runtime.
 }
 \description{
 Analyzes a log from a retrieveData run, extracts runtime information for all called functions

--- a/tests/testthat/test-findBottlenecks.R
+++ b/tests/testthat/test-findBottlenecks.R
@@ -14,16 +14,74 @@ logBugged <- c('~ Run calcOutput("TauTotal", years = 1995, round = 2, file = "fm
                '~ Exit calcOutput("TauTotal", years = 1995, round = 2, file = "fm_tau1995.cs4") in 5.56 seconds',
                '~ Exit retrieveData("example", rev = 2) in 5.58 seconds')
 
-test_that("bottleneck detection worksy", {
+# Two consecutive retrieveData runs in one log, mirroring the structure of a real diagnostics.log:
+# top-level calls have no "~" prefix, sub-calls are "~"-nested, "Run "/"Exit " entries can be split
+# across lines, and cache/statistics/NOTE lines are interspersed (and ignored during analysis).
+logMultiple <- c('Run retrieveData(model = "CellularMAgPIE", rev = list(c(4, 120)), dev = "test", puc = FALSE)',
+                 'NOTE: ',
+                 'Start preprocessing for ',
+                 'Run calcOutput(type = "Cluster", aggregate = FALSE, ctype = "c200")',
+                 '~  - loading cache calcCluster-F5730e8b3-a3c5e272.rds',
+                 'Exit calcOutput(type = "Cluster", aggregate = FALSE, ctype = "c200") in 10.42 seconds',
+                 'Run ',
+                 'calcOutput(type = "Yields", aggregate = FALSE, file = "lpj_yields_0.5.mz")',
+                 '~  - loading cache calcYields-Fe5977d47-3494a143.rds',
+                 '~ [statistics] summary of calcOutput(type = "Yields", aggregate = FALSE)',
+                 'Exit ',
+                 'calcOutput(type = "Yields", aggregate = FALSE, file = "lpj_yields_0.5.mz")',
+                 ' in 32.87 seconds',
+                 'Run calcOutput(type = "AtmosphericDeposition", aggregate = FALSE, cellular = TRUE)',
+                 '~ Run calcOutput(type = "LanduseInitialisation", aggregate = FALSE, cellular = TRUE)',
+                 '~ Exit calcOutput(type = "LanduseInitialisation", aggregate = FALSE, cellular = TRUE) in 0.31 seconds',
+                 'Exit calcOutput(type = "AtmosphericDeposition", aggregate = FALSE, cellular = TRUE) in 1.5 seconds',
+                 'Exit retrieveData(model = "CellularMAgPIE", rev = list(c(4, 120)), dev = "test", puc = FALSE) in 45.1 seconds',
+                 'Run retrieveData(model = "Validation", rev = list(c(4, 120)), puc = FALSE)',
+                 'NOTE: ',
+                 'Run calcOutput(type = "ValidGridLand", aggregate = FALSE, file = "land.mz")',
+                 '~  - loading cache calcValidGridLand-Fabcdef01.rds',
+                 'Exit calcOutput(type = "ValidGridLand", aggregate = FALSE, file = "land.mz") in 7.2 seconds',
+                 'Run calcOutput(type = "ValidCroparea", aggregate = "cluster", file = "croparea.mz")',
+                 '~ Run readSource("LUH2v2", subtype = "states")',
+                 '~ Exit readSource("LUH2v2", subtype = "states") in 4 seconds',
+                 'Exit calcOutput(type = "ValidCroparea", aggregate = "cluster", file = "croparea.mz") in 6.6 seconds',
+                 'Exit retrieveData(model = "Validation", rev = list(c(4, 120)), puc = FALSE) in 15.3 seconds')
+
+test_that("bottleneck detection works", {
   expect_message({
     x <- findBottlenecks(log)
   }, "5 seconds")
-  expect_equal(nrow(x), 3)
-  expect_equal(ncol(x), 7)
+  expect_named(x, "example")
+  expect_equal(nrow(x[["example"]]), 3)
+  expect_equal(ncol(x[["example"]]), 7)
   file <- tempfile()
   writeLines(logBugged, file)
   expect_warning({
     x <- findBottlenecks(file, unit = "h")
   }, "could not be properly detected")
+  expect_named(x, "example")
+})
+
+test_that("multiple retrieveData calls are analyzed separately", {
+  msgs <- capture_messages({
+    x <- findBottlenecks(logMultiple, unit = "s")
+  })
+  # one named entry and one "Total runtime" message per retrieveData call
+  expect_named(x, c("modelCellularMAgPIE", "modelValidation"))
+  expect_match(msgs, "Total runtime \\(modelCellularMAgPIE\\)", all = FALSE)
+  expect_match(msgs, "Total runtime \\(modelValidation\\)", all = FALSE)
+  expect_s3_class(x[["modelCellularMAgPIE"]], "data.frame")
+  expect_s3_class(x[["modelValidation"]], "data.frame")
+
+  # each block only contains its own functions (no leakage of rows between blocks)
+  expect_setequal(x[["modelCellularMAgPIE"]]$type,
+                  c("modelCellularMAgPIE", "Cluster", "Yields", "AtmosphericDeposition", "LanduseInitialisation"))
+  expect_setequal(x[["modelValidation"]]$type,
+                  c("modelValidation", "ValidGridLand", "ValidCroparea", "LUH2v2"))
+
+  # net runtimes are computed per block: the nested sub-call time is subtracted from its
+  # own parent only, and does not leak across blocks
+  valid <- x[["modelValidation"]]
+  expect_equal(valid$"net[s]"[valid$type == "ValidCroparea"], 6.6 - 4) # parent minus nested readSource
+  expect_equal(valid$"net[s]"[valid$type == "ValidGridLand"], 7.2)     # unaffected by the other block
 })
 # nolint end


### PR DESCRIPTION
This PR changes what findBottlenecks looks at in a log file. Previously it returned wrong results when encountering multiple retrieveData calls in one log. So far, the solution was to crop the file manually. This change changes the logic to extract the individual retrieveData blocks and analyze each individually. 

The alternative would be to analyze the whole log, which I would argue against, as we are typically interested in the performance of individual retrieveData blocks.