### PR TITLE
Preparations for CRAN release

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '69523100'
+ValidationKey: '69560585'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.37.0
-date-released: '2026-06-26'
+version: 3.37.1
+date-released: '2026-07-01'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.37.0
-Date: 2026-06-26
+Version: 3.37.1
+Date: 2026-07-01
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/returnCalcOutput.R
+++ b/R/returnCalcOutput.R
@@ -87,11 +87,12 @@ returnCalcOutput <- function(x, weight, unit, description,
 
   mandatoryArgs <- c("x", "weight", "unit", "description")
 
-  missing <- \(x) (is.symbol(x) && "" == format(x))
+  isMissing <- function(x) { (is.symbol(x) && "" == format(x)) }
 
-  if (length(missingMandatoryArgs <- Filter(missing, env[mandatoryArgs])))
+  if (length(missingMandatoryArgs <- Filter(isMissing, env[mandatoryArgs]))) {
     stop("argument \"", names(missingMandatoryArgs[1]),
          "\" is missing with no default")
+  }
 
-  Filter(Negate(missing), env)
+  Filter(Negate(isMissing), env)
 }

--- a/R/returnCalcOutput.R
+++ b/R/returnCalcOutput.R
@@ -87,12 +87,14 @@ returnCalcOutput <- function(x, weight, unit, description,
 
   mandatoryArgs <- c("x", "weight", "unit", "description")
 
-  isMissing <- function(x) { (is.symbol(x) && "" == format(x)) }
+  isMissing <- function(x) {
+    is.symbol(x) && "" == format(x)
+  }
 
   if (length(missingMandatoryArgs <- Filter(isMissing, env[mandatoryArgs]))) {
     stop("argument \"", names(missingMandatoryArgs[1]),
          "\" is missing with no default")
   }
 
-  Filter(Negate(isMissing), env)
+  return(Filter(Negate(isMissing), env))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.37.0**
+R package **madrat**, version **3.37.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.37.0, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.37.1, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Michael Crawford and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2026-06-26},
+  date = {2026-07-01},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.37.0},
+  note = {Version: 3.37.1},
 }
 ```

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,15 +1,23 @@
-## NOTES
+## CHANGES:
 
-The R precheck complains that "Author field differs from that derived from Authors@R". We checked
-it and the behavior is ok. It is just that the naming of affiliation and ORCID leads to slightly
-different formatting when returned, but the information stays the same.
-
-## CHANGES
-* fixed CRAN precheck error related to an error detection on a german system
-
-* fixed recently popped up testthat errors caused by stricter behavior of recent testthat versions
-* pushed version to most recent release
+- This brings the CRAN version up-to-date with recent developments in the package.
 
 ## Test environments
-* local R installation, R 4.1.2
-* rhub checks
+* local R installation, R 4.5.1
+* rhub linux using R devel
+* win-builder
+
+## R CMD check results
+
+### Local
+
+── R CMD check results 
+Duration: 3m 10.6s
+
+0 errors ✔ | 0 warnings ✔ | 0 notes ✔
+
+## revdep check results
+
+All CRAN reverse dependency checks were successful (using revdepcheck).
+
+Reviewed reverse dependencies for other repositories manually. All are covered by regular builds on r-universe / GH Action, which are successful.


### PR DESCRIPTION
Mainly updated cran-comments and applied minor changes to `returnCalcOutput` to remove the dependency on R 4.1