### PR TITLE
Rework some tests to use mocked download functions

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '69560585'
+ValidationKey: '69584592'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.37.1
-date-released: '2026-07-01'
+version: 3.37.2
+date-released: '2026-07-02'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.37.1
-Date: 2026-07-01
+Version: 3.37.2
+Date: 2026-07-02
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.37.1**
+R package **madrat**, version **3.37.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.37.1, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.37.2, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Michael Crawford and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2026-07-01},
+  date = {2026-07-02},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.37.1},
+  note = {Version: 3.37.2},
 }
 ```

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -35,3 +35,40 @@ globalassign <- function(...) {
     assign(x, eval.parent(parse(text = x)), .GlobalEnv)
   }
 }
+
+# Build small synthetic replacements for the Tau downloads once, so tests do not have to hit the
+# network (zenodo.org). Each zip mimics what downloadTau/readTau expect for a subtype: the "paper"
+# subtype reads tau_data_1995-2000.mz, the "historical" subtype reads tau_xref_history_country.mz.
+# The "total" crop band is the one calcTauTotal reads (tau.total/xref.total). The fill-source
+# countries (IDN, CHN, QAT) required by convertTau's toolCountryFill call must be present. Values are
+# synthetic, so tests must not assert on exact Tau numbers, only on structure/years.
+mockTauCountries <- c("DEU", "FRA", "USA", "IDN", "CHN", "QAT")
+
+.buildMockTauZip <- function(mzName, years) {
+  zipDir <- withr::local_tempdir(.local_envir = teardownEnv)
+  m <- new.magpie(mockTauCountries, years, c("tau.total", "xref.total"), fill = 1)
+  m[, , "xref.total"] <- 2
+  write.magpie(m, file.path(zipDir, mzName))
+  zipPath <- file.path(zipDir, "tau.zip")
+  withr::with_dir(zipDir, utils::zip(zipPath, mzName, flags = "-q"))
+  zipPath
+}
+
+mockTauZipPaper <- .buildMockTauZip("tau_data_1995-2000.mz", c(1995, 2000))
+# historical subtype: yearly data 1970-2007 (38 years), 2008 absent - matches the calcOutput checks
+mockTauZipHistorical <- .buildMockTauZip("tau_xref_history_country.mz", 1970:2007)
+
+# Mock downloadTau's network request within a test: replace the download.file binding in the madrat
+# namespace so it copies the appropriate synthetic zip (dispatched by URL) instead of downloading
+# from zenodo.org.
+localMockedTauDownload <- function(env = parent.frame()) {
+  testthat::local_mocked_bindings(
+    download.file = function(url, destfile, ...) {
+      zip <- if (any(grepl("historical", url))) mockTauZipHistorical else mockTauZipPaper
+      file.copy(zip, destfile, overwrite = TRUE)
+      0L
+    },
+    .package = "madrat",
+    .env = env
+  )
+}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -39,9 +39,8 @@ globalassign <- function(...) {
 # Build small synthetic replacements for the Tau downloads once, so tests do not have to hit the
 # network (zenodo.org). Each zip mimics what downloadTau/readTau expect for a subtype: the "paper"
 # subtype reads tau_data_1995-2000.mz, the "historical" subtype reads tau_xref_history_country.mz.
-# The "total" crop band is the one calcTauTotal reads (tau.total/xref.total). The fill-source
-# countries (IDN, CHN, QAT) required by convertTau's toolCountryFill call must be present. Values are
-# synthetic, so tests must not assert on exact Tau numbers, only on structure/years.
+# The fill-source countries (IDN, CHN, QAT) required by convertTau's toolCountryFill call must be
+# present.
 mockTauCountries <- c("DEU", "FRA", "USA", "IDN", "CHN", "QAT")
 
 .buildMockTauZip <- function(mzName, years) {

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -31,8 +31,7 @@ test_that("calcOutput will stop if unused arguments are provided", {
 })
 
 test_that("Malformed inputs are properly detected", {
-  skip_on_cran()
-  skip_if_offline("zenodo.org")
+  localMockedTauDownload()
   expect_error(localConfig(packages = "nonexistentpackage"),
                'Setting "packages" can only be set to installed packages')
   expect_error(calcOutput("TauTotal", aggregate = "wtf"),
@@ -122,20 +121,21 @@ test_that("Malformed calc outputs are properly detected", {
 })
 
 test_that("Calculation for tau example data set works", {
-  skip_on_cran()
-  skip_if_offline("zenodo.org")
+  # network request is mocked with synthetic data, so we cannot assert exact Tau values here,
+  # only the structure/years of the result (see setup.R localMockedTauDownload)
+  localMockedTauDownload()
   sink(tempfile())
   require(magclass)
   localConfig(ignorecache = FALSE, forcecache = FALSE, verbosity = 2)
-  expectedResult <- new("magpie",
-                        .Data = structure(c(0.99, 0.83, 0.68, 1.47, 0.9, 0.64, 0.8, 0.97, 1.17, 0.89, 1.27, 1.25),
-                                          .Dim = c(12L, 1L, 1L),
-                                          .Dimnames = list(region = c("LAM", "OAS", "SSA", "EUR", "NEU", "MEA",
-                                                                      "REF", "CAZ", "CHA", "IND", "JPN", "USA"),
-                                                           year = NULL, data = NULL)))
   x <- calcOutput("TauTotal", source = "historical", years = 1995, round = 2, supplementary = TRUE)
   expect_true(is.list(x))
-  expect_equivalent(x$x, expectedResult)
+  expect_s4_class(x$x, "magpie")
+  expect_equal(nyears(x$x), 1)
+  # the mocked tau is 1 everywhere, so aggregating with the (constant) xref weight yields 1 in every
+  # H12 region - assert both the aggregation happened (12 regions) and the resulting values
+  expect_setequal(getItems(x$x, 1), c("LAM", "OAS", "SSA", "EUR", "NEU", "MEA",
+                                      "REF", "CAZ", "CHA", "IND", "JPN", "USA"))
+  expect_true(all(x$x == 1))
   expect_message(x <- readSource("Tau", "historical"), "loading cache")
   expect_error(x <- readSource("Tau", "wtf"), "Unknown subtype")
   expect_warning(calcOutput("TauTotal", source = "historical", years = 1800), "Some years are missing")
@@ -375,7 +375,7 @@ test_that("1on1 country mappings do not alter the data", {
     x <- x1 * x2
     # fill with random numbers and mix order to test whether this
     # affects the country-country mapping
-    x[, , ] <- unlist(randu)[seq_len(length(x))]
+    x[, , ] <- unlist(randu)[seq_along(x)]
     x <- x[order(x), , ]
     return(list(x = x,
                 weight = NULL,

--- a/tests/testthat/test-calcOutput.R
+++ b/tests/testthat/test-calcOutput.R
@@ -121,8 +121,6 @@ test_that("Malformed calc outputs are properly detected", {
 })
 
 test_that("Calculation for tau example data set works", {
-  # network request is mocked with synthetic data, so we cannot assert exact Tau values here,
-  # only the structure/years of the result (see setup.R localMockedTauDownload)
   localMockedTauDownload()
   sink(tempfile())
   require(magclass)
@@ -131,8 +129,8 @@ test_that("Calculation for tau example data set works", {
   expect_true(is.list(x))
   expect_s4_class(x$x, "magpie")
   expect_equal(nyears(x$x), 1)
-  # the mocked tau is 1 everywhere, so aggregating with the (constant) xref weight yields 1 in every
-  # H12 region - assert both the aggregation happened (12 regions) and the resulting values
+  # mocked tau is 1, so aggregating yields 1 in every region
+  # assert both the aggregation happened and the resulting values
   expect_setequal(getItems(x$x, 1), c("LAM", "OAS", "SSA", "EUR", "NEU", "MEA",
                                       "REF", "CAZ", "CHA", "IND", "JPN", "USA"))
   expect_true(all(x$x == 1))

--- a/tests/testthat/test-metadataGFZ.R
+++ b/tests/testthat/test-metadataGFZ.R
@@ -1,6 +1,19 @@
 test_that("metadata can be extracted from GFZ dataservice", {
-  skip_on_cran()
-  skip_if_offline("doi.org")
+  # mock the network request so no real download from doi.org/GFZ is needed
+  local_mocked_bindings(
+    download.file = function(url, destfile, ...) {
+      writeLines(c(
+        paste0("<span class=\"citationtext\">Lange, Stefan (2019): EartH2Observe, WFDEI and ERA-Interim data",
+               " Merged and Bias-corrected for ISIMIP (EWEMBI). V. 1.1. GFZ Data Services.",
+               " https://doi.org/10.5880/pik.2019.004</span>"),
+        "<dt>License:</dt>",
+        "<dd>CC BY 4.0</dd>"
+      ), destfile)
+      0L
+    },
+    .package = "madrat"
+  )
+
   expect_silent({
     m <- metadataGFZ("10.5880/pik.2019.004")
   })
@@ -13,4 +26,20 @@ test_that("metadata can be extracted from GFZ dataservice", {
   expect_identical(m, mref)
   expect_error(metadataGFZ("12.3456/pik.2019.004"), "does not belong to a GFZ dataservice entry")
   expect_null(metadataGFZ(NULL))
+})
+
+test_that("metadataGFZ warns when citation or license cannot be extracted", {
+  local_mocked_bindings(
+    download.file = function(url, destfile, ...) {
+      writeLines("<html><body>no metadata here</body></html>", destfile)
+      0L
+    },
+    .package = "madrat"
+  )
+
+  w <- capture_warnings(m <- metadataGFZ("10.5880/pik.2019.004"))
+  expect_match(w, "Cannot extract citation", all = FALSE)
+  expect_match(w, "Cannot extract license", all = FALSE)
+  expect_null(m$citation)
+  expect_null(m$license)
 })

--- a/tests/testthat/test-metadataGFZ.R
+++ b/tests/testthat/test-metadataGFZ.R
@@ -1,5 +1,4 @@
 test_that("metadata can be extracted from GFZ dataservice", {
-  # mock the network request so no real download from doi.org/GFZ is needed
   local_mocked_bindings(
     download.file = function(url, destfile, ...) {
       writeLines(c(

--- a/tests/testthat/test-puc.R
+++ b/tests/testthat/test-puc.R
@@ -1,5 +1,6 @@
 test_that("puc creation works", {
   skip_on_cran()
+  localMockedTauDownload() # avoid the real Tau download triggered via calcOutput("TauTotal")
   retrieveData("example", rev = 42, extra = "test1")
   expect_true(dir.exists(getConfig("pucfolder")))
   withr::local_dir(getConfig("pucfolder"))
@@ -25,6 +26,12 @@ test_that("puc creation works", {
 test_that("puc creation is thread-safe", {
   skip_on_cran()
   skip_on_covr() # Does not work in combination with covr
+
+  # The sub-processes below cannot use the mocked download binding, so pre-populate the shared
+  # source folder with the synthetic Tau data here. readSource in the sub-processes then finds the
+  # existing source and does not hit the network.
+  localMockedTauDownload()
+  suppressMessages(readSource("Tau", "paper"))
 
   # Tip for debugging this test:
   # If something breaks in one of the sub-processes, use p1$get_result()

--- a/tests/testthat/test-puc.R
+++ b/tests/testthat/test-puc.R
@@ -1,6 +1,6 @@
 test_that("puc creation works", {
   skip_on_cran()
-  localMockedTauDownload() # avoid the real Tau download triggered via calcOutput("TauTotal")
+  localMockedTauDownload()
   retrieveData("example", rev = 42, extra = "test1")
   expect_true(dir.exists(getConfig("pucfolder")))
   withr::local_dir(getConfig("pucfolder"))

--- a/tests/testthat/test-readSource.R
+++ b/tests/testthat/test-readSource.R
@@ -57,15 +57,13 @@ test_that("readSource detects common problems", {
   convertTest <- function(x) return(as.magpie(1))
   globalassign("convertTest")
 
-  skip_on_cran()
-  skip_if_offline("zenodo.org")
+  localMockedTauDownload()
   expect_error(readSource("Tau", subtype = "paper", convert = "WTF"),
                "'convert' argument must be set to one of: TRUE, 'onlycorrect', FALSE")
 })
 
 test_that("default readSource example works", {
-  skip_on_cran()
-  skip_if_offline("zenodo.org")
+  localMockedTauDownload()
   expect_silent(suppressMessages({
     a <- readSource("Tau", "paper")
   }))
@@ -73,8 +71,7 @@ test_that("default readSource example works", {
 })
 
 test_that("downloadSource works", {
-  skip_on_cran()
-  skip_if_offline("zenodo.org")
+  localMockedTauDownload()
   localConfig(verbosity = 2, .verbose = FALSE)
   expect_error(downloadSource("Tau", "paper"),
                paste('Source folder for source "Tau/paper" does already exist. Delete that folder or call',


### PR DESCRIPTION
To improve stability and speed of tests, this PR mocks several download calls that go to actual web servers. This still does not result in tests to run through on `devtools::check` but should eliminate some of the problematic cases (also speeds up tests by about 5 seconds, not that the test suite takes long...). 