### PR TITLE
Enables findBottlenecks to also analyze top-level functions

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '69781920'
+ValidationKey: '69867980'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.37.6
-date-released: '2026-08-05'
+version: 3.38.0
+date-released: '2026-08-06'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.37.6
-Date: 2026-08-05
+Version: 3.38.0
+Date: 2026-08-06
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/findBottlenecks.R
+++ b/R/findBottlenecks.R
@@ -1,15 +1,20 @@
 #' findBottlenecks
 #'
-#' Analyzes a log from a retrieveData run, extracts runtime information for all called functions
-#' and identifies most critical bottlenecks.
+#' Analyzes a log from a retrieveData run or from a script calling calcOutput()/readSource()
+#' directly, extracts runtime information for all called functions and identifies most
+#' critical bottlenecks.
 #'
 #' @param file path to a log file or content of a log as character vector
 #' @param cumulative boolean deciding whether calls to the same function should be aggregated or not
 #' @param unit unit for runtime information, either "s" (seconds), "min" (minutes) or "h" (hours)
-#' @return A named list with one entry per retrieveData call found in the log. The names are the
-#' retrieveData types and each entry is a data.frame sorted by net runtime showing for the different
-#' data processing functions their total runtime "time" (including the execution of all sub-functions)
-#' and net runtime "net" (excluding the runtime of sub-functions) and their share of total runtime.
+#' @return A named list with one entry per retrieveData call found in the log, plus a "standalone"
+#' entry collecting all calls that do not belong to any retrieveData call (e.g. calcOutput/readSource
+#' calls made directly from a script). The names are the retrieveData types (or "standalone") and
+#' each entry is a data.frame sorted by net runtime showing for the different data processing
+#' functions their total runtime "time" (including the execution of all sub-functions) and net
+#' runtime "net" (excluding the runtime of sub-functions) and their share of total runtime. For the
+#' "standalone" entry the total runtime is the sum of its top-level call runtimes, not wall clock
+#' time, as it excludes any non-madrat time between those calls.
 #' @author Jan Philipp Dietrich
 #' @family analysis
 #' @export
@@ -21,8 +26,21 @@ findBottlenecks <- function(file, unit = "min", cumulative = TRUE) {
   }
 
   f <- .mergeSplitLogLines(f)
+
+  # Determine which lines belong to which retrieveData call. This has to happen before the
+  # log is reduced to timing lines only, as the "Run retrieveData(...)" marker that opens a
+  # block carries no runtime information of its own.
+  block <- .retrieveDataBlocks(f)
+
   # Only use the ends of blocks, nesting information is included in the prefix of each line.
-  f <- grep("in [0-9.]* seconds", f, value = TRUE)
+  keep <- grepl("in [0-9.]* seconds", f)
+  block <- block[keep]
+  f <- f[keep]
+
+  if (length(f) == 0) {
+    warning("No function calls with runtime information could be detected in the log!")
+    return(stats::setNames(list(), character(0)))
+  }
 
   x <- data.frame(level = nchar(gsub("^(~*).*$", "\\1", f)))
   x$class <- NA
@@ -38,23 +56,16 @@ findBottlenecks <- function(file, unit = "min", cumulative = TRUE) {
   x$type <- gsub("([\"= ]|type)", "", gsub("^[^(]*\\(([^,)]*)[),].*$", "\\1", f))
   x$"time[s]" <- as.numeric(gsub("^.* in ([0-9.]*) seconds.*$", "\\1", f)) # nolint
 
-  # Each retrieveData line marks the end of one retrieveData block. Split the log into one
-  # segment per retrieveData call and analyze each independently.
-  retrieveIdx <- which(x$class == "retrieve")
-  if (length(retrieveIdx) == 0) {
-    warning("No retrieveData call could be detected in the log!")
-    return(stats::setNames(list(), character(0)))
-  }
-  if (max(retrieveIdx) < nrow(x)) {
-    warning("Log lines after the last retrieveData call were ignored (incomplete block).")
+  out <- list()
+  for (id in sort(unique(block[!is.na(block)]))) {
+    rows <- which(block == id)
+    type <- x$type[rows][x$class[rows] == "retrieve"]
+    out[[type]] <- .analyzeBottlenecks(x[rows, , drop = FALSE], type, unit, cumulative)
   }
 
-  starts <- c(1, utils::head(retrieveIdx, -1) + 1)
-  out <- list()
-  for (k in seq_along(retrieveIdx)) {
-    segment <- x[starts[k]:retrieveIdx[k], , drop = FALSE]
-    type <- x$type[retrieveIdx[k]]
-    out[[type]] <- .analyzeBottlenecks(segment, type, unit, cumulative)
+  standaloneRows <- which(is.na(block))
+  if (length(standaloneRows) > 0) {
+    out[["standalone"]] <- .analyzeBottlenecks(x[standaloneRows, , drop = FALSE], "standalone", unit, cumulative)
   }
   return(out)
 }
@@ -69,6 +80,16 @@ findBottlenecks <- function(file, unit = "min", cumulative = TRUE) {
     x$"net[s]"[i] <- x$"time[s]"[i] - runtime[l + 1]
     runtime[l + 1] <- 0
   }
+
+  # Root level is -1 for retrieveData blocks (forced above), else the minimum level present.
+  # Computed before the optional cumulative aggregation below, which can merge root-level rows
+  # into fewer, differently leveled rows and so distort the total.
+  rootLevel <- min(x$level)
+  totalruntime <- sum(x$"time[s]"[x$level == rootLevel])
+  th   <- floor(totalruntime / 3600)
+  tmin <- floor((totalruntime - th * 3600) / 60)
+  ts   <- floor(totalruntime - th * 3600 - tmin * 60)
+  message("Total runtime (", type, "): ", th, " hours ", tmin, " minutes ", ts, " seconds")
 
   if (cumulative) {
     out <- NULL
@@ -92,11 +113,6 @@ findBottlenecks <- function(file, unit = "min", cumulative = TRUE) {
     x$"net[h]" <- round(x$"net[s]" / 60 / 60, 2) # nolint
   }
 
-  totalruntime <- sum(x$"time[s]"[x$level == -1])
-  th   <- floor(totalruntime / 3600)
-  tmin <- floor((totalruntime - th * 3600) / 60)
-  ts   <- floor(totalruntime - th * 3600 - tmin * 60)
-  message("Total runtime (", type, "): ", th, " hours ", tmin, " minutes ", ts, " seconds")
   x$"time[%]" <- round(x$"time[s]" / totalruntime * 100, 2) # nolint
   x$"net[%]" <- round(x$"net[s]" / totalruntime * 100, 2) # nolint
   x <- x[robustOrder(x$"net[s]", decreasing = TRUE), ]
@@ -110,10 +126,45 @@ findBottlenecks <- function(file, unit = "min", cumulative = TRUE) {
   return(x)
 }
 
+.retrieveDataBlocks <- function(f) {
+  # Assigns each line to the retrieveData block it belongs to (an integer id, in order of
+  # appearance), or NA outside any block. A block runs from "Run retrieveData(...)" to the
+  # matching "Exit retrieveData(...) in X seconds" line. retrieveData is never called from
+  # within another madrat call, so blocks cannot be nested. If an Exit has no matching Run
+  # (e.g. a truncated or pre-marker log), the block is assumed to start right after the
+  # previous one (or at line 1) -- the historic Exit-only behavior.
+  isOpen  <- grepl("^~*\\s*Run\\s+retrieveData\\(", f)
+  isClose <- grepl("^~*\\s*Exit\\s+retrieveData\\(.*in [0-9.]* seconds", f)
+
+  block <- rep(NA_integer_, length(f))
+  blockId <- 0L
+  openLine <- NA_integer_
+  lastClose <- 0L
+  for (i in seq_along(f)) {
+    if (isOpen[i]) {
+      openLine <- i
+    } else if (isClose[i]) {
+      blockId <- blockId + 1L
+      start <- if (!is.na(openLine)) openLine else lastClose + 1L
+      block[start:i] <- blockId
+      openLine <- NA_integer_
+      lastClose <- i
+    }
+  }
+  return(block)
+}
+
 .mergeSplitLogLines <- function(f) {
-  # Rejoin split log entries (long messages exceed maxLengthLogMessage and wrap to next line)
-  # This is done by looking for Exit lines that have no "in ... seconds".
-  # In that case, the loop starts accumulating content until it hits a line with "in ... seconds"
+  # Rejoin log entries split across lines when they exceed maxLengthLogMessage. An "Exit"
+  # record is complete once it contains "in ... seconds"; a "Run" record is complete once the
+  # called function's name and opening parenthesis appear. This is only ever called on lines
+  # (or accumulated fragments) starting with "Run" or "Exit", so exactly one of the two below
+  # branches always applies.
+  .isCompleteRecord <- function(line) {
+    if (grepl("^~*\\s*Exit\\b", line)) return(grepl("in [0-9.]* seconds", line))
+    return(grepl("^~*\\s*Run\\s+[[:alpha:]._][[:alnum:]._]*\\(", line))
+  }
+
   acc <- NULL
   accPrefix <- NULL
   allLines <- character(0)
@@ -122,15 +173,15 @@ findBottlenecks <- function(file, unit = "min", cumulative = TRUE) {
     if (!is.null(acc) && accPrefix == prefix) {
       rest <- trimws(sub("^~*\\s*", "", line))
       acc <- paste(trimws(acc), rest)
-      if (grepl("in [0-9.]* seconds", acc)) {
-        # We have hit the end of an exit line, stop accumulation
+      if (.isCompleteRecord(acc)) {
+        # We have hit the end of a Run/Exit record, stop accumulation
         allLines <- c(allLines, acc)
         acc <- NULL
         accPrefix <- NULL
       }
     } else {
       if (!is.null(acc)) allLines <- c(allLines, acc)
-      if (grepl("Exit", line) && !grepl("in [0-9.]* seconds", line)) {
+      if (grepl("^~*\\s*(Run|Exit)\\b", line) && !.isCompleteRecord(line)) {
         acc <- line
         accPrefix <- prefix
       } else {

--- a/R/findBottlenecks.R
+++ b/R/findBottlenecks.R
@@ -11,10 +11,10 @@
 #' entry collecting all calls that do not belong to any retrieveData call (e.g. calcOutput/readSource
 #' calls made directly from a script). The names are the retrieveData types (or "standalone") and
 #' each entry is a data.frame sorted by net runtime showing for the different data processing
-#' functions their total runtime "time" (including the execution of all sub-functions) and net
-#' runtime "net" (excluding the runtime of sub-functions) and their share of total runtime. For the
-#' "standalone" entry the total runtime is the sum of its top-level call runtimes, not wall clock
-#' time, as it excludes any non-madrat time between those calls.
+#' functions their total runtime "time" (including all sub-functions) and net runtime "net"
+#' (excluding sub-functions) and their share of total runtime. For the "standalone" entry the total
+#' runtime is the sum of its top-level call runtimes, not wall clock time, as it excludes any
+#' non-madrat time between those calls.
 #' @author Jan Philipp Dietrich
 #' @family analysis
 #' @export

--- a/R/findBottlenecks.R
+++ b/R/findBottlenecks.R
@@ -27,9 +27,7 @@ findBottlenecks <- function(file, unit = "min", cumulative = TRUE) {
 
   f <- .mergeSplitLogLines(f)
 
-  # Determine which lines belong to which retrieveData call. This has to happen before the
-  # log is reduced to timing lines only, as the "Run retrieveData(...)" marker that opens a
-  # block carries no runtime information of its own.
+  # Determine which lines belong to which retrieveData call.
   block <- .retrieveDataBlocks(f)
 
   # Only use the ends of blocks, nesting information is included in the prefix of each line.
@@ -128,11 +126,9 @@ findBottlenecks <- function(file, unit = "min", cumulative = TRUE) {
 
 .retrieveDataBlocks <- function(f) {
   # Assigns each line to the retrieveData block it belongs to (an integer id, in order of
-  # appearance), or NA outside any block. A block runs from "Run retrieveData(...)" to the
-  # matching "Exit retrieveData(...) in X seconds" line. retrieveData is never called from
-  # within another madrat call, so blocks cannot be nested. If an Exit has no matching Run
-  # (e.g. a truncated or pre-marker log), the block is assumed to start right after the
-  # previous one (or at line 1) -- the historic Exit-only behavior.
+  # appearance), or NA outside any block. retrieveData is never called from within another
+  # madrat call, so blocks cannot be nested. If an Exit has no matching Run (e.g. a truncated
+  # or pre-marker log), the block is assumed to start right after the previous one (or at line 1).
   isOpen  <- grepl("^~*\\s*Run\\s+retrieveData\\(", f)
   isClose <- grepl("^~*\\s*Exit\\s+retrieveData\\(.*in [0-9.]* seconds", f)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.37.6**
+R package **madrat**, version **3.38.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.37.6, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.38.0, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Michael Crawford and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2026-08-05},
+  date = {2026-08-06},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.37.6},
+  note = {Version: 3.38.0},
 }
 ```

--- a/man/findBottlenecks.Rd
+++ b/man/findBottlenecks.Rd
@@ -18,10 +18,10 @@ A named list with one entry per retrieveData call found in the log, plus a "stan
 entry collecting all calls that do not belong to any retrieveData call (e.g. calcOutput/readSource
 calls made directly from a script). The names are the retrieveData types (or "standalone") and
 each entry is a data.frame sorted by net runtime showing for the different data processing
-functions their total runtime "time" (including the execution of all sub-functions) and net
-runtime "net" (excluding the runtime of sub-functions) and their share of total runtime. For the
-"standalone" entry the total runtime is the sum of its top-level call runtimes, not wall clock
-time, as it excludes any non-madrat time between those calls.
+functions their total runtime "time" (including all sub-functions) and net runtime "net"
+(excluding sub-functions) and their share of total runtime. For the "standalone" entry the total
+runtime is the sum of its top-level call runtimes, not wall clock time, as it excludes any
+non-madrat time between those calls.
 }
 \description{
 Analyzes a log from a retrieveData run or from a script calling calcOutput()/readSource()

--- a/man/findBottlenecks.Rd
+++ b/man/findBottlenecks.Rd
@@ -14,14 +14,19 @@ findBottlenecks(file, unit = "min", cumulative = TRUE)
 \item{cumulative}{boolean deciding whether calls to the same function should be aggregated or not}
 }
 \value{
-A named list with one entry per retrieveData call found in the log. The names are the
-retrieveData types and each entry is a data.frame sorted by net runtime showing for the different
-data processing functions their total runtime "time" (including the execution of all sub-functions)
-and net runtime "net" (excluding the runtime of sub-functions) and their share of total runtime.
+A named list with one entry per retrieveData call found in the log, plus a "standalone"
+entry collecting all calls that do not belong to any retrieveData call (e.g. calcOutput/readSource
+calls made directly from a script). The names are the retrieveData types (or "standalone") and
+each entry is a data.frame sorted by net runtime showing for the different data processing
+functions their total runtime "time" (including the execution of all sub-functions) and net
+runtime "net" (excluding the runtime of sub-functions) and their share of total runtime. For the
+"standalone" entry the total runtime is the sum of its top-level call runtimes, not wall clock
+time, as it excludes any non-madrat time between those calls.
 }
 \description{
-Analyzes a log from a retrieveData run, extracts runtime information for all called functions
-and identifies most critical bottlenecks.
+Analyzes a log from a retrieveData run or from a script calling calcOutput()/readSource()
+directly, extracts runtime information for all called functions and identifies most
+critical bottlenecks.
 }
 \author{
 Jan Philipp Dietrich

--- a/tests/testthat/test-findBottlenecks.R
+++ b/tests/testthat/test-findBottlenecks.R
@@ -46,6 +46,36 @@ logMultiple <- c('Run retrieveData(model = "CellularMAgPIE", rev = list(c(4, 120
                  'Exit calcOutput(type = "ValidCroparea", aggregate = "cluster", file = "croparea.mz") in 6.6 seconds',
                  'Exit retrieveData(model = "Validation", rev = list(c(4, 120)), puc = FALSE) in 15.3 seconds')
 
+# A log without any retrieveData call, e.g. from a script that calls calcOutput()/readSource()
+# directly (like a MAgPIE default.cfg run).
+logStandalone <- c('Run calcOutput(type = "Parent1", aggregate = FALSE)',
+                   '~ Run readSource(type = "Src1")',
+                   '~ Exit readSource(type = "Src1") in 2 seconds',
+                   'Exit calcOutput(type = "Parent1", aggregate = FALSE) in 5 seconds',
+                   'Run calcOutput(type = "Parent2", aggregate = FALSE)',
+                   '~ Run readSource(type = "Src2")',
+                   '~ Exit readSource(type = "Src2") in 1 seconds',
+                   'Exit calcOutput(type = "Parent2", aggregate = FALSE) in 3 seconds')
+
+# Standalone calcOutput calls before, between and after two retrieveData calls.
+logMixed <- c('Exit calcOutput(type = "Lead1", aggregate = FALSE) in 3 seconds',
+              'Exit calcOutput(type = "Lead2", aggregate = FALSE) in 4 seconds',
+              'Run retrieveData(model = "A", rev = 1)',
+              '~ Run readSource(type = "Inner")',
+              '~ Exit readSource(type = "Inner") in 2 seconds',
+              'Exit retrieveData(model = "A", rev = 1) in 20 seconds',
+              'Exit calcOutput(type = "Between", aggregate = FALSE) in 1 seconds',
+              'Run retrieveData(model = "B", rev = 1)',
+              'Exit retrieveData(model = "B", rev = 1) in 6 seconds',
+              'Exit calcOutput(type = "Trail", aggregate = FALSE) in 6 seconds')
+
+# The "Run retrieveData(...)" marker itself can be wrapped across lines just like any other
+# Run/Exit record.
+logWrapped <- c('Run ',
+                'retrieveData(model = "Wrapped", rev = 1)',
+                '~ Exit calcOutput(type = "X", aggregate = FALSE) in 2 seconds',
+                'Exit retrieveData(model = "Wrapped", rev = 1) in 9 seconds')
+
 test_that("bottleneck detection works", {
   expect_message({
     x <- findBottlenecks(log)
@@ -83,5 +113,47 @@ test_that("multiple retrieveData calls are analyzed separately", {
   valid <- x[["modelValidation"]]
   expect_equal(valid$"net[s]"[valid$type == "ValidCroparea"], 6.6 - 4) # parent minus nested readSource
   expect_equal(valid$"net[s]"[valid$type == "ValidGridLand"], 7.2)     # unaffected by the other block
+
+  # percentages are still correct after moving the total runtime computation ahead of the
+  # optional cumulative aggregation: the top-level retrieveData row always accounts for 100%
+  expect_equal(x[["modelCellularMAgPIE"]]$"time[%]"[x[["modelCellularMAgPIE"]]$type == "modelCellularMAgPIE"], 100)
+  expect_equal(x[["modelValidation"]]$"time[%]"[x[["modelValidation"]]$type == "modelValidation"], 100)
+})
+
+test_that("logs without any retrieveData call are analyzed as a standalone block", {
+  expect_no_warning({
+    x <- findBottlenecks(logStandalone, unit = "s")
+  })
+  expect_named(x, "standalone")
+  d <- x[["standalone"]]
+  expect_setequal(d$type, c("Parent1", "Parent2", "Src1", "Src2"))
+  # net runtimes partition the total top-level (root level) runtime exactly
+  expect_equal(sum(d$"net[s]"), sum(d$"time[s]"[d$level == 0]))
+  expect_false(any(is.infinite(d$"time[%]")))
+  expect_false(any(is.infinite(d$"net[%]")))
+})
+
+test_that("standalone calls before, between and after retrieveData calls are kept separate", {
+  x <- findBottlenecks(logMixed, unit = "s")
+  expect_named(x, c("modelA", "modelB", "standalone"))
+  # leading, in-between and trailing standalone calls all end up in the standalone block,
+  # not attributed to the (nesting-level 0) retrieveData block that happens to follow/precede them
+  expect_setequal(x[["standalone"]]$type, c("Lead1", "Lead2", "Between", "Trail"))
+  expect_setequal(x[["modelA"]]$type, c("modelA", "Inner"))
+  expect_setequal(x[["modelB"]]$type, "modelB")
+})
+
+test_that("a wrapped 'Run retrieveData(...)' marker is still detected as a block start", {
+  x <- findBottlenecks(logWrapped, unit = "s")
+  expect_named(x, "modelWrapped")
+  expect_setequal(x[["modelWrapped"]]$type, c("modelWrapped", "X"))
+})
+
+test_that("a log without any runtime information produces an empty, named list", {
+  expect_warning({
+    x <- findBottlenecks(c("hello", "world"))
+  }, "No function calls with runtime information")
+  expect_named(x, character(0))
+  expect_length(x, 0)
 })
 # nolint end


### PR DESCRIPTION
This feature allows us to analyze the performance impact of top-level calc and read functions as we often get when running isolated benchmarks of single functions.