### PR TITLE
Improve performance of toolFixWeight slightly

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '69888651'
+ValidationKey: '69912704'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.38.1
-date-released: '2026-08-06'
+version: 3.38.2
+date-released: '2026-08-07'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.38.1
-Date: 2026-08-06
+Version: 3.38.2
+Date: 2026-08-07
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/toolFixWeight.R
+++ b/R/toolFixWeight.R
@@ -43,7 +43,7 @@
 toolFixWeight <- function(weight, map, dim) {
   dim <- dimCode(dim, weight)
   stopifnot(length(dim) == 1,
-            !any(weight < 0),
+            all(weight >= 0),
             ncol(map) == 2)
   if (!setequal(map[[2]], getItems(weight, dim))) {
     map <- map[, 2:1]

--- a/R/toolFixWeight.R
+++ b/R/toolFixWeight.R
@@ -43,7 +43,7 @@
 toolFixWeight <- function(weight, map, dim) {
   dim <- dimCode(dim, weight)
   stopifnot(length(dim) == 1,
-            weight >= 0,
+            !any(weight < 0),
             ncol(map) == 2)
   if (!setequal(map[[2]], getItems(weight, dim))) {
     map <- map[, 2:1]
@@ -52,10 +52,11 @@ toolFixWeight <- function(weight, map, dim) {
   originalDimnames <- dimnames(weight)
 
   extramap <- NULL
-  map <- unique(map[, 1:2])
+  map <- map[!duplicated(map[[2]]), 1:2]
   if (dim %in% 1:3) {
     if (ndim(weight, dim) == 1) {
-      stopifnot(!grepl(".", map, fixed = TRUE))
+      stopifnot(!grepl(".", map[[1]], fixed = TRUE),
+                !grepl(".", map[[2]], fixed = TRUE))
     } else {
       # merge all subdims into one dim, and replace back at the end using extramap
       originalMap2 <- map[[2]]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.38.1**
+R package **madrat**, version **3.38.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.38.1, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.38.2, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Michael Crawford and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2026-08-06},
+  date = {2026-08-07},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.38.1},
+  note = {Version: 3.38.2},
 }
 ```


### PR DESCRIPTION
This PR improves performance by about 1.7x, mostly through working on the data.frame columns individually instead of the complete data.frame.