### PR TITLE
Ignores some of the PUC tests again under covr

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '69867980'
+ValidationKey: '69888651'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.38.0
+version: 3.38.1
 date-released: '2026-08-06'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.38.0
+Version: 3.38.1
 Date: 2026-08-06
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.38.0**
+R package **madrat**, version **3.38.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.38.0, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.38.1, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -67,6 +67,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-08-06},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.38.0},
+  note = {Version: 3.38.1},
 }
 ```

--- a/tests/testthat/test-puc.R
+++ b/tests/testthat/test-puc.R
@@ -45,6 +45,10 @@ test_that("puc creation works", {
 
 test_that(".withLockedPuc grants exclusive access across processes", {
   skip_on_cran()
+  # "../.." (above) only locates the package source when this session has madrat loaded via
+  # pkgload::load_all() from that path. Under covr::package_coverage() tests run against a
+  # library()-installed copy in an unrelated temp dir, so the sub-process fails to load madrat.
+  skip_on_covr()
 
   pucName <- "testlock_example.puc"
   releaseFile <- file.path(withr::local_tempdir(), "release")
@@ -86,6 +90,7 @@ test_that(".withLockedPuc grants exclusive access across processes", {
 
 test_that("a second .withLockedPuc caller waits until the lock is released", {
   skip_on_cran()
+  skip_on_covr() # see the comment on the previous test
 
   pucName <- "testlock_waiting_example.puc"
   releaseFile <- file.path(withr::local_tempdir(), "release")


### PR DESCRIPTION
While #314 fixed the flakyness of the PUC tests, some of them still fail under covr. This PR adds the skip on covr again.