### PR TITLE
Changes pucAggregate to return name of the created input data archive

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '69912704'
+ValidationKey: '69994656'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.38.2
-date-released: '2026-08-07'
+version: 3.38.4
+date-released: '2026-08-19'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.38.2
-Date: 2026-08-07
+Version: 3.38.4
+Date: 2026-08-19
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/pucAggregate.R
+++ b/R/pucAggregate.R
@@ -20,6 +20,7 @@
 #' warnings will be taken more seriously and will cause 1. to have the number of
 #' warnings as prefix of the created tgz file and 2. will prevent \code{retrieveData}
 #' from creating a puc file. If set to NULL the setting will be read from the puc file.
+#' @return Invisibly, the path to the resulting tgz archive.
 #' @author Jan Philipp Dietrich
 #' @seealso
 #' \code{\link{retrieveData}},\code{\link{localConfig}}
@@ -58,7 +59,7 @@ pucAggregate <- function(puc, regionmapping = getConfig("regionmapping"), ..., r
     do.call(madrat::retrieveData, c(cfg$args, list(renv = FALSE)))
   }
 
-  with_tempdir({
+  tgzPath <- with_tempdir({
     untar(puc, exdir = "puc")
     cfg <- readRDS("puc/config.rds")
     if (!all(names(extraArgs) %in% cfg$pucArguments)) {
@@ -71,12 +72,13 @@ pucAggregate <- function(puc, regionmapping = getConfig("regionmapping"), ..., r
     cfg$args$puc <- FALSE
     if (!is.null(strict)) cfg$args$strict <- strict
     if (isTRUE(renv)) {
-      out <- capture.output(r(.aggregatePuc, list(regionmapping = regionmapping, cfg = cfg,
-                                                  madratCfg = getOption("madrat_cfg"),
-                                                  madratCodelabels = getOption("madrat_codelabels"),
-                                                  nestinglevel = getOption("gdt_nestinglevel")),
-                              spinner = FALSE, show = TRUE))
+      out <- capture.output(tgzPath <- r(.aggregatePuc, list(regionmapping = regionmapping, cfg = cfg,
+                                                             madratCfg = getOption("madrat_cfg"),
+                                                             madratCodelabels = getOption("madrat_codelabels"),
+                                                             nestinglevel = getOption("gdt_nestinglevel")),
+                                         spinner = FALSE, show = TRUE))
       message(paste(out, "\n"))
+      tgzPath
     } else {
       # only attach and detach if package is not already attached, might crash otherwise
       if (!is.null(cfg$package) && !cfg$package %in% .packages()) {
@@ -87,4 +89,5 @@ pucAggregate <- function(puc, regionmapping = getConfig("regionmapping"), ..., r
     }
   }, tmpdir = madTempDir())
   toolendmessage(startinfo)
+  return(invisible(tgzPath))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.38.2**
+R package **madrat**, version **3.38.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.38.2, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.38.4, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Michael Crawford and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2026-08-07},
+  date = {2026-08-19},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.38.2},
+  note = {Version: 3.38.4},
 }
 ```

--- a/man/pucAggregate.Rd
+++ b/man/pucAggregate.Rd
@@ -32,6 +32,9 @@ warnings will be taken more seriously and will cause 1. to have the number of
 warnings as prefix of the created tgz file and 2. will prevent \code{retrieveData}
 from creating a puc file. If set to NULL the setting will be read from the puc file.}
 }
+\value{
+Invisibly, the path to the resulting tgz archive.
+}
 \description{
 Function which takes a puc-file ("portable unaggregated collection") as created
 via \code{\link{retrieveData}} and computes the corresponding aggregated

--- a/tests/testthat/test-puc.R
+++ b/tests/testthat/test-puc.R
@@ -19,6 +19,12 @@ test_that("puc creation works", {
                               renv = FALSE), "already available")
   expect_true(file.exists(file.path(getConfig("outputfolder"), "rev42_h12_7a5441e5_example_customizable_tag.tgz")))
 
+  # pucAggregate must return the path of the archive it wrote, both when it aggregates it fresh
+  # and (via retrieveData's early return) when a matching archive already exists
+  expect_identical(basename(pucAggregate("rev42_extra_example_tag.puc", extra = "blub",
+                                         regionmapping = "regionmappingH12.csv", renv = FALSE)),
+                   "rev42_h12_7a5441e5_example_customizable_tag.tgz")
+
   expect_message(retrieveData("example", rev = 42, extra = "test2", renv = FALSE), "Run pucAggregate")
   expect_true(file.exists(file.path(getConfig("outputfolder"), "rev42_h12_5f3d77a0_example_customizable_tag.tgz")))
 })


### PR DESCRIPTION
This is then more consistent with `retrieveData` and allows for easier scripting of pucAggregate.