### PR TITLE
include mapping configuration in madrat graph hash

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '69912704'
+ValidationKey: '69977355'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '70604289'
+ValidationKey: '70628400'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.38.2
-date-released: '2026-08-07'
+version: 3.38.3
+date-released: '2026-08-20'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.41.1
-date-released: '2026-09-03'
+version: 3.41.2
+date-released: '2026-09-04'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.41.1
-Date: 2026-09-03
+Version: 3.41.2
+Date: 2026-09-04
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),
@@ -73,4 +73,4 @@ Config/Keywords: tool
 Encoding: UTF-8
 LazyData: no
 Config/Needs/website: tidyverse/tidytemplate
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.38.2
-Date: 2026-08-07
+Version: 3.38.3
+Date: 2026-08-20
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -59,67 +59,81 @@ export(vcat)
 export(visualizeDependencies)
 import(magclass)
 importFrom(callr,r)
-importFrom(igraph,"V<-")
-importFrom(igraph,V)
-importFrom(igraph,ego)
-importFrom(igraph,graph_from_data_frame)
-importFrom(igraph,make_ego_graph)
-importFrom(igraph,subcomponent)
-importFrom(igraph,union)
-importFrom(magclass,"getCells<-")
-importFrom(magclass,as.magpie)
-importFrom(magclass,collapseNames)
-importFrom(magclass,dimExists)
-importFrom(magclass,dimSums)
-importFrom(magclass,getCells)
-importFrom(magclass,getItems)
-importFrom(magclass,getNames)
-importFrom(magclass,getYears)
-importFrom(magclass,is.magpie)
-importFrom(magclass,magpie_expand)
-importFrom(magclass,mbind)
-importFrom(magclass,ncells)
-importFrom(magclass,new.magpie)
-importFrom(magclass,read.magpie)
-importFrom(magclass,setCells)
-importFrom(magclass,setYears)
-importFrom(magclass,time_interpolate)
-importFrom(magclass,where)
+importFrom(igraph,
+  "V<-",
+  V,
+  ego,
+  graph_from_data_frame,
+  make_ego_graph,
+  subcomponent,
+  union
+)
+importFrom(magclass,
+  "getCells<-",
+  as.magpie,
+  collapseNames,
+  dimExists,
+  dimSums,
+  getCells,
+  getItems,
+  getNames,
+  getYears,
+  is.magpie,
+  magpie_expand,
+  mbind,
+  ncells,
+  new.magpie,
+  read.magpie,
+  setCells,
+  setYears,
+  time_interpolate,
+  where
+)
 importFrom(methods,formalArgs)
 importFrom(pkgload,is_dev_package)
-importFrom(renv,activate)
-importFrom(renv,hydrate)
-importFrom(renv,init)
-importFrom(renv,restore)
-importFrom(renv,snapshot)
+importFrom(renv,
+  activate,
+  hydrate,
+  init,
+  restore,
+  snapshot
+)
 importFrom(stats,smooth.spline)
-importFrom(stringi,stri_extract)
-importFrom(stringi,stri_extract_all)
-importFrom(stringi,stri_match_all_regex)
-importFrom(stringi,stri_split)
-importFrom(tools,file_ext)
-importFrom(tools,file_path_sans_ext)
-importFrom(utils,askYesNo)
-importFrom(utils,bibentry)
-importFrom(utils,capture.output)
-importFrom(utils,download.file)
-importFrom(utils,installed.packages)
-importFrom(utils,modifyList)
-importFrom(utils,person)
-importFrom(utils,sessionInfo)
-importFrom(utils,str)
-importFrom(utils,tail)
-importFrom(utils,tar)
-importFrom(utils,untar)
-importFrom(utils,unzip)
-importFrom(utils,write.csv)
-importFrom(utils,write.table)
-importFrom(withr,defer)
-importFrom(withr,local_connection)
-importFrom(withr,local_dir)
-importFrom(withr,local_locale)
-importFrom(withr,local_package)
-importFrom(withr,local_tempdir)
-importFrom(withr,with_dir)
-importFrom(withr,with_tempdir)
+importFrom(stringi,
+  stri_extract,
+  stri_extract_all,
+  stri_match_all_regex,
+  stri_split
+)
+importFrom(tools,
+  file_ext,
+  file_path_sans_ext
+)
+importFrom(utils,
+  askYesNo,
+  bibentry,
+  capture.output,
+  download.file,
+  installed.packages,
+  modifyList,
+  person,
+  sessionInfo,
+  str,
+  tail,
+  tar,
+  untar,
+  unzip,
+  write.csv,
+  write.table
+)
+importFrom(withr,
+  defer,
+  local_connection,
+  local_dir,
+  local_locale,
+  local_package,
+  local_tempdir,
+  with_dir,
+  with_tempdir
+)
 importFrom(yaml,write_yaml)

--- a/R/getMadratGraph.R
+++ b/R/getMadratGraph.R
@@ -34,7 +34,13 @@ getMadratGraph <- function(packages = installedMadratUniverse(), globalenv = get
         globalenv <- FALSE
       }
     }
-    return(paste0("GH", digest::digest(c(mtimes, robustSort(packages), globalenv), algo = getConfig("hash"))))
+    # the "mappings" attribute of the graph is resolved by .getMappingFiles() (see getCode)
+    # against the mapping configuration active at build time. Reusing a cached graph after
+    # that configuration changed yields stale mapping paths, which propagate into
+    # fingerprint() and therefore into the cache file names of all dependent calculations.
+    mappingConfig <- c(getConfig("regionmapping"), getConfig("extramappings"), getConfig("mappingfolder"))
+    return(paste0("GH", digest::digest(c(mtimes, robustSort(packages), globalenv,
+                                         robustSort(mappingConfig)), algo = getConfig("hash"))))
   }
 
   gHash <- .graphHash(packages, globalenv)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.38.2**
+R package **madrat**, version **3.38.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.38.2, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>. Version: 3.38.3, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Michael Crawford and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2026-08-07},
+  date = {2026-08-20},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.38.2},
+  note = {Version: 3.38.3},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.41.1**
+R package **madrat**, version **3.41.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.41.1, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>. Version: 3.41.2, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Michael Crawford and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2026-09-03},
+  date = {2026-09-04},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.41.1},
+  note = {Version: 3.41.2},
 }
 ```


### PR DESCRIPTION
getMadratGraph() caches the dependency graph in the in-session MadratCache, keyed by digest(mtimes, packages, globalenv). The graph's mappings attribute, however, is resolved by .getMappingFiles() against the mapping configuration active when it was built. Changing regionmapping within one session therefore reuses a graph carrying stale mapping paths; fingerprint() hashes those, and every dependent calculation resolves to the previous mapping's cache entry.

Observed in MAgPIE preprocessing: a run that computed clusters under regionmappingH12.csv and then switched to regionmappingFSEC.csv in the same session silently reused the H12 cluster result (calcCluster-F09b8144c-…) and wrote it out under the FSEC name, producing a cellular dataset whose clustermap contained 12 H12 regions instead of the 14 FSEC ones. Identical scenarios run in separate processes correctly produced calcCluster-F27e7b4af-…. There is no error — the output looks valid.

This adds regionmapping, extramappings and mappingfolder to the graph hash so a mapping switch invalidates the cached graph. Only paths are hashed; mapping contents are already covered by fingerprint() via fingerprintFiles(). Cost is one graph rebuild per mapping switch; unchanged workflows are unaffected.

Related: 56d45cbf ("preparing to include mapping files in cache hashing (incomplete)").