### PR TITLE
Speed up main case of toolTimeSpline considerably

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '70135710'
+ValidationKey: '70366400'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.39.0
-date-released: '2026-08-24'
+version: 3.40.0
+date-released: '2026-08-31'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation
   and management, rudimentary quality management, data caching, work-flow management

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.39.0
-Date: 2026-08-24
+Version: 3.40.0
+Date: 2026-08-31
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/toolTimeSpline.R
+++ b/R/toolTimeSpline.R
@@ -80,12 +80,60 @@ toolTimeSpline <- function(x,
 
   ## 5) Apply over time-series (dim 2 inner)
   arrIn <- as.array(x)
-  arrOut <- apply(arrIn, c(1, 3), tmpspline, df = dfValue)
+  d     <- dim(arrIn)
+  nseries <- d[1] * d[3]
+
+  # smooth.spline() requires 1 < df <= n (#unique x); outside that range it
+  # silently ignores df and picks a df via GCV instead (with a warning), which
+  # makes the fit data-dependent and breaks the linearity argument below. Only
+  # take the fast path when dfValue is valid, so smooth.spline's own choice of
+  # df is guaranteed identical (and therefore linear) across all series.
+  validDf <- dfValue > 1 && dfValue <= nyr
+
+  if (nseries >= nyr && validDf) {
+    # smooth.spline with fixed x, w and df is a *linear* smoother: for any
+    # input y, fitted = smoothMat %*% y, where smoothMat depends only on
+    # (years, wts, df) and not on the data itself. Build smoothMat once from
+    # the nyr unit vectors (via the unchanged tmpspline() above, so it stays
+    # in sync with any edge-case behaviour of smooth.spline), then replace
+    # nseries individual smooth.spline() calls with per-band matrix
+    # multiplications. This is algebraically identical to the direct
+    # per-series apply() below and only pays off once there are at least as
+    # many series as spline evaluations required to build smoothMat.
+    #
+    # Note: deliberately *not* done via a single aperm()'d (nyr x nseries)
+    # matrix -- on objects with tens of thousands of cells that aperm (plus
+    # the one needed to transpose back) each materialise a full extra copy of
+    # x, multiplying peak memory well past what apply() below needs. Looping
+    # per band and right-multiplying keeps the cell axis untouched, so the
+    # only extra full-size buffer is the (already unavoidable) output array.
+    if (anyNA(arrIn)) {
+      stop("toolTimeSpline: x contains NA values, which smooth.spline cannot handle.")
+    }
+    smoothMat <- vapply(seq_len(nyr), function(i) {
+      unit <- numeric(nyr)
+      unit[i] <- 1
+      tmpspline(unit, dfValue)
+    }, numeric(nyr))
+    smoothMatT <- t(smoothMat)
+
+    arrOut <- array(NA_real_, dim = d, dimnames = dimnames(arrIn))
+    for (b in seq_len(d[3])) {
+      # matrix() (rather than relying on [ , , b]'s default drop behaviour)
+      # keeps this correct when d[1] == 1
+      cellMat <- matrix(arrIn[, , b], nrow = d[1], ncol = nyr)
+      arrOut[, , b] <- cellMat %*% smoothMatT
+    }
+  } else {
+    arrOut <- apply(arrIn, c(1, 3), tmpspline, df = dfValue)
+    dimnames(arrOut)[[1]] <- dimnames(arrIn)[[2]]
+    arrOut <- aperm(arrOut, c(2, 1, 3))
+  }
 
   ## 6) Reconstruct magpie object
-  dimnames(arrOut)[[1]] <- getYears(x)
-  names(dimnames(arrOut))[1] <- getSets(x, fulldim = FALSE)[2]
-  out <- as.magpie(arrOut, spatial = 2, temporal = 1)
+  dimnames(arrOut)[[2]] <- getYears(x)
+  names(dimnames(arrOut))[2] <- getSets(x, fulldim = FALSE)[2]
+  out <- as.magpie(arrOut, spatial = 1, temporal = 2)
 
   # Correct for negative values if needed
   if (!negative) out[out < 0] <- 0

--- a/R/toolTimeSpline.R
+++ b/R/toolTimeSpline.R
@@ -51,7 +51,7 @@ toolTimeSpline <- function(x,
   ## 3) Build weight vector
   if (is.null(peggedYears)) {
     # no anchors
-    wts <- rep(1, nyr)
+    weights <- rep(1, nyr)
     peggedYearsAll <- NULL
   } else {
     # parse user‐supplied anchors (allow "yYYYY" or numeric)
@@ -62,8 +62,8 @@ toolTimeSpline <- function(x,
       stop("One or more user-supplied anchors not in data years.")
     }
 
-    wts <- rep(1, nyr)
-    wts[years %in% peggedYearsAll] <- nyr * anchorFactor
+    weights <- rep(1, nyr)
+    weights[years %in% peggedYearsAll] <- nyr * anchorFactor
   }
 
   ## 4) Per-series spline (uses fit$y so no predict() call)
@@ -71,7 +71,7 @@ toolTimeSpline <- function(x,
     fit <- stats::smooth.spline(
       x            = years,
       y            = ts,
-      w            = wts,
+      w            = weights,
       df           = df,
       control.spar = list(high = 2)
     )

--- a/R/toolTimeSpline.R
+++ b/R/toolTimeSpline.R
@@ -108,20 +108,14 @@ toolTimeSpline <- function(x,
     # per band and right-multiplying keeps the cell axis untouched, so the
     # only extra full-size buffer is the (already unavoidable) output array.
     #
-    # This path is algebraically identical to the per-series apply() below,
-    # not bit-identical: replacing nseries individual smooth.spline() calls
-    # with a matrix multiply reorders the underlying floating-point sums, so
-    # results agree only to ~1e-14 relative (verified against 184M values of
-    # real LPJmL output, comparing this fast path to the direct apply() path
-    # below run through mstools::toolHarmonize2Baseline). That is far below
-    # any physically meaningful threshold, but a value
-    # whose true magnitude is within ~1e-14 of zero can round to a different
-    # sign than the reference implementation, and downstream `x < 0 -> 0`
-    # clamps (including the one a few lines below) turn that into a visible
-    # 0-vs-nonzero difference. Callers that branch on exact zero anywhere in
-    # their pipeline should treat that as a pre-existing fragility -- any
-    # change in summation order (BLAS, R version, compiler) triggers it
-    # equally -- not as something introduced by taking this fast path.
+    # Algebraically identical to apply() below, not bit-identical: reordering
+    # the floating-point sums means results agree only to ~1e-14 relative
+    # (verified against 184M values of real LPJmL output). Harmless on its
+    # own, but a value within ~1e-14 of zero can round to a different sign
+    # than the reference implementation, and a downstream `x < 0 -> 0` clamp
+    # turns that into a visible 0-vs-nonzero difference -- a pre-existing
+    # fragility in any caller that branches on exact zero, not something this
+    # fast path introduces.
     if (anyNA(arrIn)) {
       stop("toolTimeSpline: x contains NA values, which smooth.spline cannot handle.")
     }

--- a/R/toolTimeSpline.R
+++ b/R/toolTimeSpline.R
@@ -107,6 +107,21 @@ toolTimeSpline <- function(x,
     # x, multiplying peak memory well past what apply() below needs. Looping
     # per band and right-multiplying keeps the cell axis untouched, so the
     # only extra full-size buffer is the (already unavoidable) output array.
+    #
+    # This path is algebraically identical to the per-series apply() below,
+    # not bit-identical: replacing nseries individual smooth.spline() calls
+    # with a matrix multiply reorders the underlying floating-point sums, so
+    # results agree only to ~1e-14 relative (verified against 184M values of
+    # real LPJmL output, comparing this fast path to the direct apply() path
+    # below run through mstools::toolHarmonize2Baseline). That is far below
+    # any physically meaningful threshold, but a value
+    # whose true magnitude is within ~1e-14 of zero can round to a different
+    # sign than the reference implementation, and downstream `x < 0 -> 0`
+    # clamps (including the one a few lines below) turn that into a visible
+    # 0-vs-nonzero difference. Callers that branch on exact zero anywhere in
+    # their pipeline should treat that as a pre-existing fragility -- any
+    # change in summation order (BLAS, R version, compiler) triggers it
+    # equally -- not as something introduced by taking this fast path.
     if (anyNA(arrIn)) {
       stop("toolTimeSpline: x contains NA values, which smooth.spline cannot handle.")
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.39.0**
+R package **madrat**, version **3.40.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.39.0, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.40.0, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,9 +64,9 @@ A BibTeX entry for LaTeX users is
   title = {madrat: May All Data be Reproducible and Transparent (MADRaT) *},
   author = {Jan Philipp Dietrich and Pascal Sauer and Lavinia Baumstark and Stephen Wirth and Anastasis Giannousakis and Renato Rodrigues and Benjamin Leon Bodirsky and Debbora Leip and Michael Crawford and Ulrich Kreidenweis and David Klein and Patrick Rein},
   doi = {10.5281/zenodo.1115490},
-  date = {2026-08-24},
+  date = {2026-08-31},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.39.0},
+  note = {Version: 3.40.0},
 }
 ```


### PR DESCRIPTION
`toolTimeSpline` is responsible for a considerable percentage of the preprocessing duration. This PR speeds up the main case of toolTimeSpline to reduce that time.

The optimization is based on the insight that our application of `smooth.spline` is actually a linear smoother that does not depend on the actual data but only on the number of years, weights, and degrees of freedom. Thus, we can pre-calculate the factors once using `smooth.spline` and then simply apply it to our data.

The results are equivalent but not bit-identical as the floating point matrix multiplication can lead to different results at the level of floating-point inaccuracies.

The algorithm-side of this was reviewed by @k4rst3ns and me.

Impact on `mrmfa` was evaluated by checking for changes on `calcCoGDP` and `calcCoPopulation`, which both showed no change at all.