### PR TITLE
Extends compareData to also show detailed diff information on request

### DIFF
--- a/R/compareData.R
+++ b/R/compareData.R
@@ -1,3 +1,105 @@
+# float32 ULP at magnitude v: the gap between adjacent float32 values in v's
+# binade. write.magpie stores 23 mantissa bits (IEEE-754 single), so an .mz
+# round-trip cannot resolve a difference smaller than this -- it is pure
+# storage rounding, not a computation difference.
+.float32Ulp <- function(v) {
+  v <- abs(v)
+  out <- numeric(length(v))
+  nz <- v > 0
+  out[nz] <- 2^(floor(log2(v[nz])) - 23)
+  out
+}
+
+# Classify every differing element of two equal-length numeric arrays into
+# noise / zero-flip / genuine / NA-mismatch buckets. Runs in chunks so memory
+# stays bounded by chunkSize rather than by the full arrays; x and y must
+# already be loaded (this does not read anything from disk).
+#
+# `float32` picks the noise rule: TRUE applies a float32-ULP tolerance, which
+# is only justified when at least one side went through .mz's float32
+# storage; FALSE falls back to a relative `reassocTol`, appropriate for
+# formats (.rds, .cs3/.cs4, ...) that store doubles throughout and so have no
+# rounding step to blame for small gaps.
+#
+# zero-flip: one side is exactly 0 and the other is dust (< zeroEps) -- e.g. a
+# reordered floating-point computation flipping a near-zero value across a
+# downstream `x < 0 -> 0` clamp. Gated by zeroEps so a real 0-vs-large
+# difference is never miscounted as noise. Not automatically safe to ignore:
+# a dust-sized flip can be amplified by a downstream consumer that branches on
+# exact zero.
+.classifyDiffs <- function(x, y, float32, zeroEps = 1e-6, reassocTol = 1e-9, chunkSize = 5e6) {
+  n <- length(x)
+  nNoise <- 0L
+  nZeroFlip <- 0L
+  nGenuine <- 0L
+  nNAmismatch <- 0L
+  sumAbsDiff <- 0
+  sumAbsY <- 0
+  maxGenuineRel <- 0
+  maxGenuineAbs <- 0
+  genuineExampleIdx <- NA_integer_
+
+  pos <- 0L
+  while (pos < n) {
+    chunkLen <- min(chunkSize, n - pos)
+    idx <- (pos + 1):(pos + chunkLen)
+    oldChunk <- x[idx]
+    newChunk <- y[idx]
+    sumAbsY <- sumAbsY + sum(abs(newChunk), na.rm = TRUE)
+
+    isNaOld <- is.na(oldChunk)
+    isNaNew <- is.na(newChunk)
+    nNAmismatch <- nNAmismatch + sum(xor(isNaOld, isNaNew))
+    bothPresent <- !isNaOld & !isNaNew
+    diffIdx <- which(bothPresent & oldChunk != newChunk)
+
+    if (length(diffIdx)) {
+      oldVal <- oldChunk[diffIdx]
+      newVal <- newChunk[diffIdx]
+      delta <- newVal - oldVal
+      absDelta <- abs(delta)
+      sumAbsDiff <- sumAbsDiff + sum(absDelta)
+      # diffIdx already excludes oldChunk == newChunk, so at least one of
+      # oldVal, newVal is nonzero and this denominator is always > 0.
+      relDiff <- absDelta / pmax(abs(oldVal), abs(newVal))
+
+      # when exactly one side is 0, abs(delta) equals the magnitude of the other side
+      isZeroFlip <- ((oldVal == 0) != (newVal == 0)) & absDelta < zeroEps
+      bothNonzero <- oldVal != 0 & newVal != 0
+
+      if (float32) {
+        u <- .float32Ulp(pmax(abs(oldVal), abs(newVal)))
+        isNoise <- bothNonzero & !isZeroFlip & absDelta <= 2 * u
+      } else {
+        isNoise <- bothNonzero & !isZeroFlip & relDiff <= reassocTol
+      }
+      isGenuine <- !isZeroFlip & !isNoise
+
+      nZeroFlip <- nZeroFlip + sum(isZeroFlip)
+      nNoise    <- nNoise    + sum(isNoise)
+      nGenuine  <- nGenuine  + sum(isGenuine)
+
+      if (any(isGenuine)) {
+        genuineIdx <- which(isGenuine)
+        worstGenuineIdx <- genuineIdx[which.max(relDiff[genuineIdx])]
+        if (relDiff[worstGenuineIdx] > maxGenuineRel) {
+          maxGenuineRel <- relDiff[worstGenuineIdx]
+          maxGenuineAbs <- absDelta[worstGenuineIdx]
+          genuineExampleIdx <- pos + diffIdx[worstGenuineIdx]
+        }
+      }
+    }
+    pos <- pos + chunkLen
+  }
+
+  list(n = n, nNoise = nNoise, nZeroFlip = nZeroFlip, nGenuine = nGenuine,
+       nNAmismatch = nNAmismatch,
+       nDiff = nNoise + nZeroFlip + nGenuine + nNAmismatch,
+       sumAbsDiff = sumAbsDiff, sumAbsY = sumAbsY,
+       maxGenuineRel = maxGenuineRel, maxGenuineAbs = maxGenuineAbs,
+       genuineExampleIdx = genuineExampleIdx)
+}
+
 #' compareData
 #'
 #' Compares the content of two data archives and looks for similarities and differences
@@ -8,6 +110,13 @@
 #' get ignored
 #' @param yearLim year until when the comparison should be performed.
 #' Useful to check if data is identical until a certain year.
+#' @param detailed if TRUE, files that differ are additionally broken down into
+#' storage/reassociation noise, zero-flips (one side exactly 0, the other dust --
+#' see the "zero-flip" note in the printed report), and genuine differences. This
+#' is purely diagnostic: it doesn't change the OK/DIFF verdict.
+#' @return Invisibly, a list with the ok/skip/diff/miss counts, the file lists, and
+#' (if \code{detailed = TRUE}) a \code{details} list of per-file difference
+#' statistics keyed by file name.
 #' @author Jan Philipp Dietrich, Florian Humpenoeder
 #' @family validation
 #' @seealso \code{\link{setConfig}}, \code{\link{calcTauTotal}},
@@ -16,7 +125,7 @@
 #' @export
 
 compareData <- function(x, y, tolerance = 10^-5, # nolint: cyclocomp_linter
-                        yearLim = NULL) {
+                        yearLim = NULL, detailed = FALSE) {
   tDir <- local_tempdir()
 
   .getDir <- function(tDir, file, name) {
@@ -78,6 +187,41 @@ compareData <- function(x, y, tolerance = 10^-5, # nolint: cyclocomp_linter
     if (is.null(attr(x, "status"))) x else NULL
   }
 
+  # Report the noise/zero-flip/genuine/NA-mismatch breakdown for one differing
+  # file pair. Returns the stats list, or NULL if the two objects could not be
+  # aligned into comparable flat arrays (e.g. duplicate dimnames within a
+  # dimension).
+  .reportDetailed <- function(x, y, xFile, yFile) {
+    if (!identical(dimnames(x), dimnames(y))) {
+      aligned <- try(y[dimnames(x)[[1]], dimnames(x)[[2]], dimnames(x)[[3]]], silent = TRUE)
+      if (inherits(aligned, "try-error")) {
+        message("             detailed comparison skipped (dimnames not alignable)")
+        return(NULL)
+      }
+      y <- aligned
+    }
+
+    float32 <- any(grepl("\\.mz$", c(xFile, yFile), ignore.case = TRUE))
+    st <- .classifyDiffs(x@.Data, y@.Data, float32 = float32)
+    noiseLabel <- if (float32) "float32-ULP" else "reassoc-noise"
+
+    message(sprintf("             elements %d | differing %d (%.4f%%)",
+                    st$n, st$nDiff, 100 * st$nDiff / st$n))
+    message(sprintf("             %s %d | zero-flip %d | genuine %d | NA-mismatch %d",
+                    noiseLabel, st$nNoise, st$nZeroFlip, st$nGenuine, st$nNAmismatch))
+    if (st$nZeroFlip > 0) {
+      message("             note: zero-flips are dust-sized (< 1e-06) -- check downstream ",
+              "consumers that branch on exact zero before treating them as safe")
+    }
+    if (st$nGenuine > 0) {
+      message(sprintf("             max genuine: rel %g, abs %g at flat index %d",
+                      st$maxGenuineRel, st$maxGenuineAbs, st$genuineExampleIdx))
+    }
+    message(sprintf("             aggregate relative error (sum|diff|/sum|y|): %g",
+                    if (st$sumAbsY > 0) st$sumAbsDiff / st$sumAbsY else NA))
+    return(st)
+  }
+
   i <- 1
   for (f in out$files$inBoth) {
     counter <- format(paste0("(", i, "/", length(out$files$inBoth), ") "), width = 10)
@@ -108,12 +252,19 @@ compareData <- function(x, y, tolerance = 10^-5, # nolint: cyclocomp_linter
           out$diff <- out$diff + 1
         } else {
           diff <- max(abs(x - y), na.rm = TRUE)
-          if (!identical(x, y) && diff > tolerance) {
+          identicalXY <- identical(x, y)
+          if (!identicalXY && diff > tolerance) {
             message("!= values (max diff = ", round(diff, 8), ")")
             out$diff <- out$diff + 1
           } else {
             message("OK")
             out$ok <- out$ok + 1
+          }
+          if (detailed && !identicalXY) {
+            st <- .reportDetailed(x, y, xFile, yFile)
+            if (!is.null(st)) {
+              out$details[[f]] <- st
+            }
           }
         }
       }
@@ -121,4 +272,5 @@ compareData <- function(x, y, tolerance = 10^-5, # nolint: cyclocomp_linter
   }
 
   message("[OK ", out$ok, " | DIFF ", out$diff, " | SKIP ", out$skip, " | MISS ", out$miss, "]")
+  return(invisible(out))
 }

--- a/man/compareData.Rd
+++ b/man/compareData.Rd
@@ -4,7 +4,7 @@
 \alias{compareData}
 \title{compareData}
 \usage{
-compareData(x, y, tolerance = 10^-5, yearLim = NULL)
+compareData(x, y, tolerance = 10^-5, yearLim = NULL, detailed = FALSE)
 }
 \arguments{
 \item{x}{Either a tgz file or a folder containing data sets}
@@ -16,6 +16,18 @@ get ignored}
 
 \item{yearLim}{year until when the comparison should be performed.
 Useful to check if data is identical until a certain year.}
+
+\item{detailed}{if TRUE, files that differ are additionally broken down into
+storage/reassociation noise, zero-flips (one side exactly 0, the other dust --
+see the "zero-flip" note in the printed report), and genuine differences. This
+is purely diagnostic: it never changes the OK/DIFF verdict, which is still
+governed by \code{tolerance} alone. Both files are held in memory at once, same
+as the rest of \code{compareData}, so this is not suitable for very large files.}
+}
+\value{
+Invisibly, a list with the ok/skip/diff/miss counts, the file lists, and
+(if \code{detailed = TRUE}) a \code{details} list of per-file difference
+statistics keyed by file name.
 }
 \description{
 Compares the content of two data archives and looks for similarities and differences

--- a/tests/testthat/test-compareData.R
+++ b/tests/testthat/test-compareData.R
@@ -10,3 +10,79 @@ test_that("compareData works", {
   expectation <- "[OK 2 | DIFF 0 | SKIP 1 | MISS 0]"
   expect_message(compareData(testdir, testdir), expectation, class = "fixed")
 })
+
+# Two empty magpie objects (all cells zeroed) sharing one region/year/names
+# layout, ready for the caller to overwrite specific cells with old/new pairs.
+.compareDataTestPair <- function(names) {
+  tDir <- withr::local_tempdir(.local_envir = parent.frame())
+  oldDir <- file.path(tDir, "old")
+  newDir <- file.path(tDir, "new")
+  dir.create(oldDir)
+  dir.create(newDir)
+
+  m <- magclass::new.magpie(cells_and_regions = c("AAA.1", "AAA.2"), years = 2000, names = names)
+  old <- m
+  new <- m
+  old[is.na(old)] <- 0
+  new[is.na(new)] <- 0
+
+  list(oldDir = oldDir, newDir = newDir, old = old, new = new)
+}
+
+test_that("compareData detailed classifies .mz differences into buckets", {
+  p <- .compareDataTestPair(c("noise", "zeroflip", "genuine", "namismatch", "exact"))
+  oldDir <- p$oldDir
+  newDir <- p$newDir
+  old <- p$old
+  new <- p$new
+
+  u <- 2^(floor(log2(100)) - 23) # float32 ULP at magnitude 100
+  old["AAA.1", 2000, "noise"] <- 100
+  new["AAA.1", 2000, "noise"] <- 100 + 2 * u        # within 2 ULP -> float32-ULP noise
+  old["AAA.1", 2000, "zeroflip"] <- 0
+  new["AAA.1", 2000, "zeroflip"] <- 1e-9            # dust vs exact zero -> zero-flip
+  old["AAA.1", 2000, "genuine"] <- 100
+  new["AAA.1", 2000, "genuine"] <- 101              # 1% off -> genuine
+  old["AAA.1", 2000, "namismatch"] <- NA
+  new["AAA.1", 2000, "namismatch"] <- 5             # NA vs number -> NA-mismatch
+  old["AAA.1", 2000, "exact"] <- 42
+  new["AAA.1", 2000, "exact"] <- 42                 # identical -> not counted
+
+  write.magpie(old, file.path(oldDir, "animal.mz"))
+  write.magpie(new, file.path(newDir, "animal.mz"))
+
+  plain <- compareData(oldDir, newDir, detailed = FALSE)
+  detailed <- compareData(oldDir, newDir, detailed = TRUE)
+
+  # detailed must never change the OK/DIFF/SKIP/MISS verdict
+  expect_identical(plain[c("ok", "diff", "skip", "miss")], detailed[c("ok", "diff", "skip", "miss")])
+
+  st <- detailed$details[["animal.mz"]]
+  expect_equal(st$n, 10)
+  expect_equal(st$nNoise, 1)
+  expect_equal(st$nZeroFlip, 1)
+  expect_equal(st$nGenuine, 1)
+  expect_equal(st$nNAmismatch, 1)
+  expect_equal(st$nDiff, 4)
+})
+
+test_that("compareData detailed uses reassoc-noise (not float32-ULP) for non-.mz formats", {
+  p <- .compareDataTestPair(c("noise", "genuine"))
+  oldDir <- p$oldDir
+  newDir <- p$newDir
+  old <- p$old
+  new <- p$new
+
+  old["AAA.1", 2000, "noise"] <- 100
+  new["AAA.1", 2000, "noise"] <- 100 * (1 + 1e-10)  # below reassocTol -> noise
+  old["AAA.1", 2000, "genuine"] <- 100
+  new["AAA.1", 2000, "genuine"] <- 100 * (1 + 1e-3) # above reassocTol -> genuine
+
+  write.magpie(old, file.path(oldDir, "x.rds"))
+  write.magpie(new, file.path(newDir, "x.rds"))
+
+  detailed <- compareData(oldDir, newDir, detailed = TRUE)
+  st <- detailed$details[["x.rds"]]
+  expect_equal(st$nNoise, 1)
+  expect_equal(st$nGenuine, 1)
+})


### PR DESCRIPTION
`compareData` is already very helpful to detect whether input data change in unexpected ways, however in case of a difference the diagnostic information was very limited. This extends the diagnostic information to determine whether changes are genuine value changes or floating point artifacts.