### PR TITLE
Changes memory profiling option 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '70583590'
+ValidationKey: '70604289'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'madrat: May All Data be Reproducible and Transparent (MADRaT) *'
-version: 3.41.0
+version: 3.41.1
 date-released: '2026-09-03'
 abstract: Provides a framework which should improve reproducibility and transparency
   in data processing. It provides functionality such as automatic meta data creation

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: madrat
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 3.41.0
+Version: 3.41.1
 Date: 2026-09-03
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/R/calcOutput.R
+++ b/R/calcOutput.R
@@ -268,7 +268,7 @@ calcOutput <- function(type, aggregate = TRUE, file = NULL, years = NULL, # noli
 
   # deferred handlers run in reverse order of registration, so registering this before
   # toolendmessage makes the memory report show up after the corresponding exit message
-  if (isTopLevelCall && isTRUE(getConfig("memoryProfiling", raw = TRUE))) {
+  if (isTopLevelCall && isTRUE(getConfig("memoryprofiling", raw = TRUE))) {
     memoryStart <- startMemoryProfiling()
     withr::defer({
       reportMemoryProfiling(memoryStart, callString)

--- a/R/initializeConfig.R
+++ b/R/initializeConfig.R
@@ -39,7 +39,7 @@ initializeConfig <- function(verbose = TRUE) {
                 hash                 = "xxhash32",
                 diagnostics          = FALSE,
                 debug                = FALSE,
-                memoryProfiling      = FALSE,
+                memoryprofiling      = isTRUE(as.logical(Sys.getenv("MADRAT_MEMORYPROFILING", unset = FALSE))),
                 maxLengthLogMessage = 200)
     options(madrat_cfg = cfg) # nolint
     if (verbose) {

--- a/R/setConfig.R
+++ b/R/setConfig.R
@@ -71,7 +71,7 @@
 #' debug=TRUE will add the suffix "debug" to the files created to avoid there use in productive runs.
 #' Furthermore, with debug=TRUE calculations will be rerun even if a corresponding tgz file
 #' already exists.
-#' @param memoryProfiling Boolean which activates memory profiling. If active, every top-level
+#' @param memoryprofiling Boolean which activates memory profiling. If active, every top-level
 #' \code{\link{calcOutput}} call reports its memory usage to the log: the peak memory usage during
 #' the stage as well as the usage before and after it. The reported numbers are the resident set size of
 #' the R process as recorded by the kernel, so any other data held in the same session is counted as well.
@@ -125,7 +125,7 @@ setConfig <- function(..., # nolint: cyclocomp_linter.
                       hash = NULL,
                       diagnostics = NULL,
                       debug = NULL,
-                      memoryProfiling = NULL,
+                      memoryprofiling = NULL,
                       maxLengthLogMessage = NULL,
                       redirections = NULL,
                       .cfgchecks = TRUE,
@@ -192,7 +192,7 @@ setConfig <- function(..., # nolint: cyclocomp_linter.
     cacheFormat(cacheformat)
   }
 
-  if (isTRUE(memoryProfiling) && .cfgchecks && !memoryProfilingSupported()) {
+  if (isTRUE(memoryprofiling) && .cfgchecks && !memoryProfilingSupported()) {
     warning("Memory profiling requires the Linux /proc interface and will be skipped on this system.")
   }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # May All Data be Reproducible and Transparent (MADRaT) *
 
-R package **madrat**, version **3.41.0**
+R package **madrat**, version **3.41.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/madrat)](https://cran.r-project.org/package=madrat) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1115490.svg)](https://doi.org/10.5281/zenodo.1115490) [![R build status](https://github.com/pik-piam/madrat/workflows/check/badge.svg)](https://github.com/pik-piam/madrat/actions) [![codecov](https://codecov.io/gh/pik-piam/madrat/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/madrat) [![r-universe](https://pik-piam.r-universe.dev/badges/madrat)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **madrat** in publications use:
 
-Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.41.0, <https://github.com/pik-piam/madrat>.
+Dietrich J, Sauer P, Baumstark L, Wirth S, Giannousakis A, Rodrigues R, Bodirsky B, Leip D, Crawford M, Kreidenweis U, Klein D, Rein P (2026). "madrat: May All Data be Reproducible and Transparent (MADRaT) *." doi:10.5281/zenodo.1115490 <https://doi.org/10.5281/zenodo.1115490>, Version: 3.41.1, <https://github.com/pik-piam/madrat>.
 
 A BibTeX entry for LaTeX users is
 
@@ -67,6 +67,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-09-03},
   year = {2026},
   url = {https://github.com/pik-piam/madrat},
-  note = {Version: 3.41.0},
+  note = {Version: 3.41.1},
 }
 ```

--- a/man/setConfig.Rd
+++ b/man/setConfig.Rd
@@ -28,7 +28,7 @@ setConfig(
   hash = NULL,
   diagnostics = NULL,
   debug = NULL,
-  memoryProfiling = NULL,
+  memoryprofiling = NULL,
   maxLengthLogMessage = NULL,
   redirections = NULL,
   .cfgchecks = TRUE,
@@ -126,7 +126,7 @@ debug=TRUE will add the suffix "debug" to the files created to avoid there use i
 Furthermore, with debug=TRUE calculations will be rerun even if a corresponding tgz file
 already exists.}
 
-\item{memoryProfiling}{Boolean which activates memory profiling. If active, every top-level
+\item{memoryprofiling}{Boolean which activates memory profiling. If active, every top-level
 \code{\link{calcOutput}} call reports its memory usage to the log: the peak memory usage during
 the stage as well as the usage before and after it. The reported numbers are the resident set size of
 the R process as recorded by the kernel, so any other data held in the same session is counted as well.

--- a/tests/testthat/test-memoryProfiling.R
+++ b/tests/testthat/test-memoryProfiling.R
@@ -23,7 +23,7 @@ allocateBallast <- function() {
 
 localProfiling <- function(env = parent.frame()) {
   testthat::skip_if_not(memoryProfilingSupported(), "requires the Linux /proc interface")
-  setConfig(verbosity = 1, memoryProfiling = TRUE, .verbose = FALSE, .local = env)
+  setConfig(verbosity = 1, memoryprofiling = TRUE, .verbose = FALSE, .local = env)
 }
 
 test_that("getProcMemory returns plausible values", {
@@ -51,12 +51,12 @@ test_that("reportMemoryProfiling does nothing without a profile", {
 
 test_that("setConfig warns if memory profiling is unsupported", {
   local_mocked_bindings(memoryProfilingSupported = function() return(FALSE))
-  expect_warning(localConfig(memoryProfiling = TRUE, .verbose = FALSE), "Linux /proc interface")
+  expect_warning(localConfig(memoryprofiling = TRUE, .verbose = FALSE), "Linux /proc interface")
 })
 
 test_that("nothing is reported if memory profiling is unsupported", {
   local_mocked_bindings(memoryProfilingSupported = function() return(FALSE))
-  localConfig(verbosity = 1, memoryProfiling = TRUE, .verbose = FALSE, .cfgchecks = FALSE)
+  localConfig(verbosity = 1, memoryprofiling = TRUE, .verbose = FALSE, .cfgchecks = FALSE)
   calcMemUnsupported <- function() return(memoryPayload("MemUnsupported"))
   globalassign("calcMemUnsupported")
 


### PR DESCRIPTION
This PR does two things
1.) Allow memory profiling to be activated via MADRAT_MEMORYPROFILING
2.) Changes the option to `memoryprofiling` to stay consistent with the other options and the env var schema